### PR TITLE
support isolated networks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -97,6 +97,7 @@ virt_infra_host_networks:
   absent: []
   present:
     - name: "default"
+      type: "nat"
       ip_address: "192.168.112.1"
       subnet: "255.255.255.0"
       dhcp_start: "192.168.112.2"

--- a/templates/virt-network.j2
+++ b/templates/virt-network.j2
@@ -1,14 +1,23 @@
 <network>
   <name>{{ item.name | default("default") }}</name>
-  <forward mode='nat'>
+  <mac address='{{ item.mac | default("52:54:00" | random_mac) }}'/>
+  {% if item.domain is defined and item.domain %}
+  <domain name="{{ item.domain }}"/>
+  {% endif %}
+  {% if (item.type is undefined or (item.type is defined and item.type == "nat")) and item.ip_address is defined and item.ip_address %}
+  <forward mode='nat'{% if item.nat_dev is defined and item.nat_dev %} dev='{{ item.nat_dev }}'{% endif %}>
     <nat>
       <port start='1024' end='65535'/>
     </nat>
   </forward>
-  <mac address='{{ "52:54:00" | random_mac }}'/>
+  {% endif %}
+  {% if item.ip_address is defined and item.ip_address %}
   <ip address='{{ item.ip_address | default("192.168.122.1") }}' netmask='{{ item.subnet | default("255.255.255.0") }}'>
+    {% if item.dhcp_start is defined and item.dhcp_start and item.dhcp_end is defined and item.dhcp_end %}
     <dhcp>
       <range start='{{ item.dhcp_start |default("192.168.122.2") }}' end='{{ item.dhcp_end |default("192.168.122.254") }}'/>
     </dhcp>
+    {% endif %}
   </ip>
+  {% endif %}
 </network>


### PR DESCRIPTION
The network template expected NAT and DHCP, however sometimes it might
be useful to have an isolated network without DHCP or NAT.

This can be achieved by specifying the type to "isolated". You can also
have a NAT network without DHCP by leaving out DHCP ranges. Backwards
compatible behaviour is maintained by making NAT the default type,
however NAT only works if you specify a network range and IP address.
Thus, if both `type` and ip_address` are not specified then it will be
isolated.

Example NAT network with DHCP:
  - name: "example-nat-dhcp"
    ip_address: "192.168.112.1"
    subnet: "255.255.255.0"
    dhcp_start: "192.168.112.2"
    dhcp_end: "192.168.112.99"

Example NAT network without DHCP:
  - name: "example-nat-no-dhcp"
    type: "nat"
    ip_address: "192.168.112.1"
    subnet: "255.255.255.0"

Example isolated network:
  - name: "example-isolated"

Example isolated network with DHCP:
  - name: "example-isolated-dhcp"
    type: "isolated"
    ip_address: "192.168.112.1"
    subnet: "255.255.255.0"
    dhcp_start: "192.168.112.100"
    dhcp_end: "192.168.112.99"