### PR TITLE
Register RHEL guests to ports for package install

### DIFF
--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -106,6 +106,11 @@
   command: >
     virt-customize
     -a {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
+    {% if virt_infra_sm_creds is defined and virt_infra_sm_creds %}
+    --sm-register
+    --sm-credentials {{ virt_infra_sm_creds }}
+    --sm-attach {{ virt_infra_sm_attach | default("auto") }}
+    {% endif %}
     --install qemu-guest-agent,cloud-init
   register: result_disk_deps
   retries: 10
@@ -115,6 +120,27 @@
   when:
     - inventory_hostname not in groups['kvmhost']
     - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - virt_infra_state != "undefined"
+  delegate_to: "{{ groups['kvmhost'][0] }}"
+
+- name: Remove RHEL registration
+  command: >
+    virt-customize
+    -a {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
+    {% if virt_infra_sm_creds is defined and virt_infra_sm_creds %}
+    --sm-remove
+    --sm-unregister
+    --sm-credentials {{ virt_infra_sm_creds }}
+    {% endif %}
+  register: result_disk_unregister
+  retries: 10
+  delay: 2
+  until: result_disk_unregister is succeeded
+  become: true
+  when:
+    - inventory_hostname not in groups['kvmhost']
+    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - virt_infra_sm_creds is defined and virt_infra_sm_creds
     - virt_infra_state != "undefined"
   delegate_to: "{{ groups['kvmhost'][0] }}"
 


### PR DESCRIPTION
If you're using RHEL guest, installing packages (including cloud-init)
requires the guest to be registered to the portal.

This is too tricky. If you're using RHEL do it manually in your base
image.