### PR TITLE
skip deps install into rhel vm if no portal creds

### DIFF
--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -120,6 +120,7 @@
   when:
     - inventory_hostname not in groups['kvmhost']
     - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - not ('rhel' in virt_infra_variant and (virt_infra_sm_creds is undefined or virt_infra_sm_creds is defined and not virt_infra_sm_creds))
     - virt_infra_state != "undefined"
   delegate_to: "{{ groups['kvmhost'][0] }}"
 


### PR DESCRIPTION
If spinning up a RHEL guest without specifying portal credentials, this
step will fail. As the cloud image already has cloud-init this is not
strictly necessary, so we can not skip attempting this if no creds were
provided.