### PR TITLE
support ssd for scsi disks and dynamic controllers

### DIFF
--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -7,6 +7,9 @@
     --boot hd
     --connect {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     --cpu {{ virt_infra_cpu_model }}
+    --controller type=scsi,model=virtio-scsi,index=0
+    {% set scsi_disk_count = [] %}
+    {% set scsi_controller_count = [] %}
     {% for disk in virt_infra_disks %}
     {% if disk.bus is defined and disk.bus == "nvme" %}
     --qemu-commandline='-drive file={{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ disk.name }}.qcow2,format=qcow2,if=none,id={{ disk.name | upper }}'
@@ -14,10 +17,22 @@
     {% else %}
     --disk {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ disk.name }}.qcow2,serial={{ disk.name }},{% if disk.name == "boot" %}boot_order=1,{% endif %}format=qcow2,bus={{ disk.bus | default(virt_infra_disk_bus) }}{% if disk.cache is defined and disk.cache %},cache={{ disk.cache }}{% endif %}{% if disk.io is defined and disk.io %},io={{ disk.io }}{% endif %}
     {% endif %}
+    {% if disk.bus is defined and disk.bus == "scsi" and disk.ssd is defined and disk.ssd | bool == true %}
+    --qemu-commandline='-set device.scsi{{ scsi_controller_count | length }}-0-0-{{ scsi_disk_count | length }}.rotation_rate=1'
+    {% endif %}
+    {% if disk.bus is defined and disk.bus == "scsi" %}
+    {% set __ = scsi_disk_count.append(1) %}
+    {% endif %}
+    {% if scsi_disk_count | length > 6  %}
+    {% set __ = scsi_disk_count.clear() %}
+    {% set __ = scsi_controller_count.append(1) %}
+    --controller type=scsi,model=virtio-scsi,index={{ scsi_controller_count | length }}
+    {% endif %}
     {% endfor %}
+    {% if scsi_disk_count | length > 2  %}
+    --controller type=scsi,model=virtio-scsi,index={{ ( scsi_controller_count | length ) + 1 }}
+    {% endif %}
     --disk {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso,device=cdrom,bus=scsi,format=iso
-    --controller type=scsi,model=virtio-scsi,index=0
-    --controller type=scsi,model=virtio-scsi,index=1
     --channel unix,target_type=virtio,name=org.qemu.guest_agent.0
     --graphics spice
     --machine {{ virt_infra_machine_type }}


### PR DESCRIPTION
SCSI disks can set new variable of 'ssd = true' in the YAML inventory in
order to set them as non-rotational disks (SSDs).

In order to enable SSD support we must know the alias of the disk, which
unfortunately we are not able to define ourselves with virt-install.

The alias is generated from the controller number and the disk location
on that controller. For example, 'scsi0-0-0-1' is the second device on
the first controller. This format is only true for the virtio-scsi
controller, the LSI controller would have a slightly different format
'scsi0-0-1' for the same disk.

In order to calculate the alias, we need to know which controller the
disk is on and its location. And in order to do that, we need to count
the number of SCSI disks as well as the controllers.

The SCSI controllers have a max of 7 devices before a second controller
is required. Thus, we need to add a second controller once the number of
SCSI disks reaches 7.

Lastly, even though a controller supports up to 7 disks, if there is
more than 3, then libvirt puts the CD-ROM onto a new controller.
Unfortunately this is LSI by default which means your disk and the
CD-ROM are not on the same bus. This can result in detection or timing
issues, causing cloud-init to fail as the CD-ROM is not detected before
the system keeps booting from the OS disk.

Therefore, we have to add an extra virtio-scsi controller when the
number of disks reaches more than 3, so that the CD-ROM is on the same
bus as the root disk.

To make this work I had to be able to increment a counter in Ansible.
The only way I could do that reliably on anything less than Jinja 2.10
(which solves scope issue) is to use a list and its length. It might not
be pretty, but it works. I'll gladly buy a beverage for anyone who shows
me a better way to do it!