### PR TITLE
add support for custom VM MAC addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can create private NAT libvirt networks on the KVM host and then put VMs on
 any number of them. Guests can use those libvirt networks or _existing_ bridge
 devices (e.g. br0) and Open vSwitch (OVS) bridge on the KVM host (this won't
 create bridges on the host, but it will check that the bridge interface
-exists).
+exists). You can specify the MAC for each interface if you require.
 
 This supports various distros and uses their qcow2 [cloud
 images](#guest-cloud-images) for convenience (although you could use your own
@@ -558,7 +558,8 @@ example:
       - name: "data"
         bus: "sata"
     virt_infra_networks:
-      - "example"
+      - name: "example"
+        mac: 52:54:00:aa:bb:cc
 ```
 
 ## Example Playbook

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -39,11 +39,11 @@
     --name {{ inventory_hostname }}
     {% for network in virt_infra_networks %}
     {% if network.type is defined and network.type == "bridge" %}
-    --network bridge={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}
+    --network bridge={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}
     {% elif network.type is defined and network.type == "ovs" %}
-    --network network={{ network.name }},portgroup={{ network.portgroup }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}
+    --network network={{ network.name }},portgroup={{ network.portgroup }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}
     {% else %}
-    --network network={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}
+    --network network={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}
     {% endif %}
     {% endfor %}
     --noreboot


### PR DESCRIPTION
It may be useful to specify a MAC address for VMs so that they are
always the same when recreated. For example, when they are used for
external DHCP leases on a bridged network, or for PXE boot, etc.

This adds a new "mac" YAML option for VM network interfaces and works
with every network type, e.g.:

  test-0:
    virt_infra_networks:
      - name: br0
        type: bridge
        mac: 52:54:00:aa:bb:cc