### PR TITLE
add support for virtual bmc

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,6 +93,15 @@ virt_infra_host_image_path: "/var/lib/libvirt/images"
 # This is overridden in distro specific vars
 virt_infra_security_driver: "none"
 
+# Virtual BMC is disabled by default
+virt_infra_vbmc: false
+
+# By default we install with pip, but if you prefer to do it manually, set this to false
+virt_infra_vbmc_pip: true
+
+# Default vbmc service, override if something else on your distro
+virt_infra_vbmc_service: vbmcd
+
 # Networks on kvmhost are a list, you can add more than one
 # You can create and remove NAT networks on kvmhost (creating bridges not supported)
 # The 'default' network is the standard one shipped with libvirt

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,1 +1,28 @@
 ---
+# vbmcd does not always remove ports or start properly on the fly
+# restarting the daemon helps make it more reliable
+# however ansible doesn't seem to ensure it actually came back up
+# so perform manual stop and start
+- name: "Stop virtualbmc daemon"
+  service:
+    name: "{{ virt_infra_vbmc_service | default('vbmcd') }}"
+    state: stopped
+    enabled: yes
+  listen: "restart virtual bmc"
+  register: result_vbmcd_stop
+  become: true
+  changed_when: true
+  delegate_to: "{{ groups['kvmhost'][0] }}"
+  run_once: true
+
+- name: "Start virtualbmc daemon"
+  service:
+    name: "{{ virt_infra_vbmc_service | default('vbmcd') }}"
+    state: started
+    enabled: yes
+  listen: "restart virtual bmc"
+  register: result_vbmcd_start
+  become: true
+  changed_when: true
+  delegate_to: "{{ groups['kvmhost'][0] }}"
+  run_once: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,10 +9,13 @@
 - include_tasks: pool-create.yml
 - include_tasks: disk-create.yml
 - include_tasks: virt-create.yml
+- include_tasks: vbmc-create.yml
 - include_tasks: net-list.yml
 - include_tasks: virt-list.yml
+- include_tasks: vbmc-list.yml
 - include_tasks: virt-remove.yml
 - include_tasks: disk-remove.yml
+- include_tasks: vbmc-remove.yml
 - include_tasks: hosts-add.yml
 - include_tasks: hosts-remove.yml
 - include_tasks: wait.yml

--- a/tasks/validations.yml
+++ b/tasks/validations.yml
@@ -191,6 +191,139 @@
         - result_apparmor_conf.changed
       become: true
 
+    - name: "KVM host only: Ensure system package of virtualbmc is removed"
+      package:
+        name: "python3-virtualbmc"
+        state: absent
+      become: true
+      register: result_vbmc_remove
+      retries: 30
+      delay: 5
+      until: result_vbmc_remove is succeeded
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+      ignore_errors: true
+
+    - name: "KVM host only: Advise unable to remove virtualbmc host package"
+      set_fact:
+        validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to remove vbmc host package'] }}"
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+        - result_vbmc_remove.failed
+      changed_when: true
+
+    - name: "KVM host only: Install virtualbmc with pip"
+      pip:
+        name: virtualbmc  {%- if virt_infra_vbmc_pip_version is defined %}=={{ virt_infra_vbmc_pip_version }}{% endif %}
+      register: result_vbmc_pip
+      ignore_errors: yes
+      retries: 30
+      delay: 5
+      until: result_vbmc_pip is succeeded
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+      become: true
+
+    - name: "KVM host only: Advise unable to install virtualbmc"
+      set_fact:
+        validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to install virtualbmc with pip'] }}"
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+        - result_vbmc_pip.failed
+      changed_when: true
+
+    - name: "KVM host only: Create virtualbmc service file"
+      template:
+        src: templates/vbmcd.service.j2
+        dest: "/etc/systemd/system/vbmcd.service"
+        mode: '0644'
+      become: true
+      register: result_vbmc_service
+      ignore_errors: yes
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+
+    - name: "KVM host only: Advise unable to create virtualbmc service"
+      set_fact:
+        validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to create virtualbmc service'] }}"
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+        - result_vbmc_service.failed
+      changed_when: true
+
+    - name: "KVM host only: Create virtualbmc config directory"
+      file:
+        path: /etc/virtualbmc
+        state: directory
+        mode: '0755'
+      become: true
+      ignore_errors: yes
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+
+    - name: "KVM host only: Create virtualbmc run directory"
+      file:
+        path: /var/lib/vbmcd
+        state: directory
+        mode: '0755'
+      become: true
+      ignore_errors: yes
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+
+    - name: "KVM host only: Create config for virtualbmc"
+      template:
+        src: templates/virtualbmc.conf.j2
+        dest: "/etc/virtualbmc/virtualbmc.conf"
+        mode: '0644'
+      ignore_errors: yes
+      become: true
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+
+    - name: "KVM host only: Ensure virtualbmc is running"
+      systemd:
+        name: "{{ virt_infra_vbmc_service }}"
+        state: started
+        daemon_reload: yes
+        enabled: yes
+      register: result_virtualbmc
+      ignore_errors: yes
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc
+      become: true
+
+    - name: "KVM host only: Advise unable to start virtualbmc"
+      set_fact:
+        validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to start and enable virtualbmc'] }}"
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc
+        - result_virtualbmc.failed is defined and result_virtualbmc.failed
+      changed_when: true
+
+    - name: "KVM host only: Get virtual BMC list"
+      shell: vbmc list -f json --noindent |sed 's/Domain name/Name/g'
+      register: result_vbmc_list
+      become: true
+      args:
+        executable: /bin/bash
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc
+        - result_virtualbmc.failed is defined and not result_virtualbmc.failed
+      changed_when: false
+
     - name: Advise when deps are not installed
       set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ 'KVM host: ' +  item.item + ' not found on KVM host, please install'] }}"
@@ -315,6 +448,28 @@
         - hostvars[groups['kvmhost'][0]].result_osinfo.stdout is defined
         - virt_infra_variant is defined
         - virt_infra_variant not in hostvars[groups['kvmhost'][0]].result_osinfo.stdout
+      changed_when: true
+
+    - name: "Guests: Check that existing vbmc port and name match"
+      set_fact:
+        validations_failed: "{{ validations_failed|default([]) + ['vbmc port exists on ' + item.Port | string + ' but does not match definition of ' + virt_infra_vbmc_port | string ] }}"
+      when:
+        - inventory_hostname not in groups['kvmhost']
+        - virt_infra_vbmc_port is defined
+        - hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout is defined and hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout
+        - item.Name == inventory_hostname and item.Port != virt_infra_vbmc_port
+      with_items: "{{ hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout }}"
+      changed_when: true
+
+    - name: "Guests: Check that vbmc port does not conflict with existing"
+      set_fact:
+        validations_failed: "{{ validations_failed|default([]) + ['vbmc port ' + item.Port | string + ' conflicts with ' + item.Name ] }}"
+      when:
+        - inventory_hostname not in groups['kvmhost']
+        - virt_infra_vbmc_port is defined
+        - hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout is defined and hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout
+        - item.Name != inventory_hostname and item.Port == virt_infra_vbmc_port
+      with_items: "{{ hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout }}"
       changed_when: true
 
     # - name: "Check that disks don't already exist for guest"

--- a/tasks/vbmc-create.yml
+++ b/tasks/vbmc-create.yml
@@ -1,0 +1,47 @@
+---
+# Create any virtual BMC interfaces
+- name: Create virtual BMC
+  shell: >
+    vbmc add {{ hostvars[item]['inventory_hostname'] }}
+    --libvirt-uri {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
+    --port {{ hostvars[item]['virt_infra_vbmc_port'] }}
+    --username {{ hostvars[item]['vbmc_user'] | default('admin') }}
+    --password {{ hostvars[item]['vbmc_password'] | default('password') }}
+  args:
+    executable: /bin/bash
+  become: true
+  register: result_vbmc_create
+  retries: 10
+  delay: 2
+  until: result_vbmc_create is succeeded
+  when:
+    - hostvars[item]['inventory_hostname'] not in groups['kvmhost']
+    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) != "undefined"
+    - hostvars[item]['virt_infra_vbmc_port'] is defined and hostvars[item]['virt_infra_vbmc_port']
+    - hostvars[groups["kvmhost"][0]].virt_infra_vbmc is defined and hostvars[groups["kvmhost"][0]].virt_infra_vbmc or virt_infra_vbmc
+    - hostvars[groups["kvmhost"][0]].result_vbmc_list.stdout is defined and hostvars[item]['inventory_hostname'] not in hostvars[groups["kvmhost"][0]].result_vbmc_list.stdout
+  delegate_to: "{{ groups['kvmhost'][0] }}"
+  with_items: "{{ play_hosts }}"
+  run_once: true
+  notify:
+    - restart virtual bmc
+
+- name: Start virtual BMC
+  shell: "vbmc start {{ hostvars[item]['inventory_hostname'] }}"
+  args:
+    executable: /bin/bash
+  become: true
+  register: result_vbmc_start
+  retries: 10
+  delay: 2
+  until: result_vbmc_start is succeeded
+  changed_when: false
+  when:
+    - hostvars[item]['inventory_hostname'] not in groups['kvmhost']
+    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) != "undefined"
+    - hostvars[item]['virt_infra_vbmc_port'] is defined and hostvars[item]['virt_infra_vbmc_port']
+    - hostvars[groups["kvmhost"][0]].virt_infra_vbmc is defined and hostvars[groups["kvmhost"][0]].virt_infra_vbmc or virt_infra_vbmc
+  delegate_to: "{{ groups['kvmhost'][0] }}"
+  with_items: "{{ play_hosts }}"
+
+- meta: flush_handlers

--- a/tasks/vbmc-list.yml
+++ b/tasks/vbmc-list.yml
@@ -1,0 +1,12 @@
+---
+# This is only run on KVM host
+- name: Get virtual BMC list
+  shell: vbmc list -f json --noindent |sed 's/Domain name/Name/g'
+  register: result_vbmc_list
+  become: true
+  args:
+    executable: /bin/bash
+  when:
+    - inventory_hostname in groups['kvmhost']
+    - hostvars[groups["kvmhost"][0]].virt_infra_vbmc is defined and hostvars[groups["kvmhost"][0]].virt_infra_vbmc or virt_infra_vbmc
+  changed_when: false

--- a/tasks/vbmc-remove.yml
+++ b/tasks/vbmc-remove.yml
@@ -1,0 +1,23 @@
+---
+- name: Remove virtual BMC
+  shell: "vbmc delete {{ hostvars[item]['inventory_hostname'] }}"
+  args:
+    executable: /bin/bash
+  become: true
+  register: result_vbmc_remove
+  retries: 10
+  delay: 2
+  until: result_vbmc_remove is succeeded
+  when:
+    - hostvars[item]['inventory_hostname'] not in groups['kvmhost']
+    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "undefined"
+    - hostvars[item]['virt_infra_vbmc_port'] is defined and hostvars[item]['virt_infra_vbmc_port']
+    - hostvars[groups["kvmhost"][0]].virt_infra_vbmc is defined and hostvars[groups["kvmhost"][0]].virt_infra_vbmc or virt_infra_vbmc
+    - hostvars[groups["kvmhost"][0]].result_vbmc_list is defined and hostvars[item]['inventory_hostname'] in hostvars[groups["kvmhost"][0]].result_vbmc_list.stdout
+  delegate_to: "{{ groups['kvmhost'][0] }}"
+  with_items: "{{ play_hosts }}"
+  run_once: true
+  notify:
+    - restart virtual bmc
+
+- meta: flush_handlers

--- a/templates/vbmcd.service.j2
+++ b/templates/vbmcd.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=VirtualBMC daemon
+Documentation=https://docs.openstack.org/virtualbmc/latest/user/index.html
+After=libvirtd.service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/var/lib/vbmcd
+ExecStart=/usr/local/bin/vbmcd --foreground
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/virtualbmc.conf.j2
+++ b/templates/virtualbmc.conf.j2
@@ -1,0 +1,9 @@
+[default]
+config_dir=/root/.vbmc
+
+[log]
+logfile=/var/log/virtualbmc/virtualbmc.log
+debug=True
+
+[ipmi]
+session_timout=20

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -10,6 +10,7 @@ virt_infra_host_pkgs_deps:
   - python3
   - python3-libvirt
   - python3-lxml
+  - python3-pip
   - qemu-img
   - virt-install
 

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -14,6 +14,7 @@ virt_infra_host_pkgs_deps:
   - libvirt-clients
   - python3-libvirt
   - python3-lxml
+  - python3-pip
   - qemu-utils
   - virtinst
 

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -9,6 +9,7 @@ virt_infra_host_pkgs_deps:
   - libosinfo
   - python3-libvirt
   - python3-lxml
+  - python3-pip
   - qemu-img
   - virt-install
 

--- a/vars/opensuse.yml
+++ b/vars/opensuse.yml
@@ -11,6 +11,7 @@ virt_infra_host_pkgs_deps:
   - mkisofs
   - python3-libvirt-python
   - python3-lxml
+  - python3-pip
   - qemu-tools
   - virt-install
 

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -12,6 +12,7 @@ virt_infra_host_pkgs_deps:
   - libvirt-clients
   - python3-libvirt
   - python3-lxml
+  - python3-pip
   - qemu-utils
   - virtinst
 


### PR DESCRIPTION
This enables option for creating and removing vbmc interfaces for
guests, so that they can be controlled with IPMI.

By default vbmc is disabled, set this in kvmhost vars to enable it:

  virt_infra_vbmc: true

If enabled, by default this will install the latest virtualbmc from pip and
configure it to run as root. You may specify a specific version of
virtualbmc, e.g. 1.6.0, with the following var:

  virt_infra_vbmc_pip_version: 1.6.0

However, Fedora and openSUSE do package virtualbmc, so if you'd rather
use the system package (or install it manually), you can disable pip
install:

  virt_infra_vbmc_pip: false

The default service is called "vbmcd" so if it is called something else
on your distro (like "virtualbmc") then specify it with the following on
kvmhost:

  virt_infra_vbmc_service: virtualbmc

The Ansible will do some simple checks to make sure that the port is not
already in use by a different host.

This adds some new vars for guests, the only required one is `vbmc_port`
as each VM needs to be on a dedicated UDP port on the KVM host.

  ipmi-guest:
    virt_infra_vbmc_port: 62300
    virt_infra_vbmc_user: admin
    virt_infra_vbmc_password: password

You can see your running virtual BMC interfaces with vbmc tool.

 $ sudo vbmc list
 +-------------+---------+---------+-------+
 | Domain name | Status  | Address |  Port |
 +-------------+---------+---------+-------+
 | ipmi-guest  | running | ::      | 62300 |
 +-------------+---------+---------+-------+

You should now be able to interact with it using ipmitool.

 $ ipmitool -I lanplus -H localhost -p 62300 -U admin -P password power status
 Chassis Power is on

Finally, this doesn't automatically punch a hole in your firewall, so if
you have one you might want to open the range you use.

 $ sudo firewall-cmd --zone libvirt --add-port=62300-62399/udp