### PR TITLE
add support to set qemu security driver

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -89,6 +89,10 @@ virt_infra_host_libvirt_url: "qemu:///system"
 # Path where disk images are kept
 virt_infra_host_image_path: "/var/lib/libvirt/images"
 
+# Disable qemu security driver by default
+# This is overridden in distro specific vars
+virt_infra_security_driver: "none"
+
 # Networks on kvmhost are a list, you can add more than one
 # You can create and remove NAT networks on kvmhost (creating bridges not supported)
 # The 'default' network is the standard one shipped with libvirt

--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -49,9 +49,9 @@
 - name: Set permissions on NVMe disk images
   file:
     path: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
-    owner: "{{ virt_infra_host_image_owner | default('root') }}"
-    group: "{{ virt_infra_host_image_group | default('qemu') }}"
-    mode: "{{ virt_infra_host_image_mode | default('0660') }}"
+    owner: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_owner | default('root') }}"
+    group: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_group | default('qemu') }}"
+    mode: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_mode | default('0660') }}"
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']

--- a/tasks/validations.yml
+++ b/tasks/validations.yml
@@ -100,6 +100,34 @@
         executable: /bin/bash
       changed_when: false
 
+    # Set security driver on qemu (none/selinux/apparmor)
+    # RHEL/CentOS/Fedora/openSUSE are set to selinux by default
+    # Debian/Ubuntu are set to apparmor by default
+    # Defaults to "none" when not specified, which enables use of NVMe drives successfully on all distros
+    # Else we get permissions denied on NVMe disk images
+    - name: "KVM host only: Set libvirtd security driver"
+      lineinfile:
+        path: /etc/libvirt/qemu.conf
+        insertafter: '^#security_driver ='
+        regexp: '^security_driver ='
+        line: 'security_driver = "{{ virt_infra_security_driver }}"'
+      register: result_qemuconf
+      when:
+        - inventory_hostname in groups['kvmhost']
+      become: true
+
+    - name: "KVM host only: Restart libvirtd if config changed"
+      service:
+        name: "libvirtd"
+        state: restarted
+        enabled: yes
+      register: result_libvirtd_restart
+      ignore_errors: yes
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - result_qemuconf.changed
+      become: true
+
     - name: "KVM host only: Ensure libvirtd is running"
       service:
         name: "libvirtd"
@@ -137,6 +165,31 @@
         - inventory_hostname in groups['kvmhost']
         - result_libvirtd.list_vms is not defined
       changed_when: true
+
+    # Allow MAC access to NVMe drives when using apparmor
+    # Else we get permissions denied on NVMe disk images
+    - name: "KVM host only: Enable access to NVMe drives in apparmor"
+      lineinfile:
+        path: /etc/apparmor.d/abstractions/libvirt-qemu
+        line: '  /var/lib/libvirt/images/*nvme.qcow2 rwk,'
+      register: result_apparmor_conf
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_security_driver is defined and virt_infra_security_driver == "apparmor"
+      become: true
+
+    - name: "KVM host only: Restart apparmor if config changed"
+      service:
+        name: "apparmor"
+        state: restarted
+        enabled: yes
+      register: result_apparmor
+      ignore_errors: yes
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_security_driver is defined and virt_infra_security_driver == "apparmor"
+        - result_apparmor_conf.changed
+      become: true
 
     - name: Advise when deps are not installed
       set_fact:

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -12,3 +12,5 @@ virt_infra_host_pkgs_deps:
   - python3-lxml
   - qemu-img
   - virt-install
+
+virt_infra_security_driver: selinux

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -16,3 +16,8 @@ virt_infra_host_pkgs_deps:
   - python3-lxml
   - qemu-utils
   - virtinst
+
+virt_infra_host_image_owner: libvirt-qemu
+virt_infra_host_image_group: libvirt-qemu
+
+virt_infra_security_driver: apparmor

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -11,3 +11,5 @@ virt_infra_host_pkgs_deps:
   - python3-lxml
   - qemu-img
   - virt-install
+
+virt_infra_security_driver: selinux

--- a/vars/opensuse.yml
+++ b/vars/opensuse.yml
@@ -13,4 +13,7 @@ virt_infra_host_pkgs_deps:
   - python3-lxml
   - qemu-tools
   - virt-install
+
 virt_infra_mkiso_cmd: mkisofs
+
+virt_infra_security_driver: selinux

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -14,3 +14,8 @@ virt_infra_host_pkgs_deps:
   - python3-lxml
   - qemu-utils
   - virtinst
+
+virt_infra_host_image_owner: libvirt-qemu
+virt_infra_host_image_group: libvirt-qemu
+
+virt_infra_security_driver: apparmor


### PR DESCRIPTION
    Most distros implement mandatory access controls like SELinux and
    Apparmor around libvirt. However, NVMe drives are attached via extra
    qemu commands and this causes launching of guests to fail as access to
    the drives is blocked.
    
    This change adds a new variable `virt_infra_security_driver` which lets
    you set the mandatory access control driver you want to use. By default
    this is set to "none" which disables it, however RPM distros are set to
    "selinux" while Deb based distros are set to "apparmor" by default.
    
    On Fedora, setting the right ownership of the drives seems to make this
    work with SELinux. However, this is not enough on Debian and Ubuntu where
    Apparmor still blocks reading with an error like this:
    
      audit: type=1400 audit(1588465721.729:1232):
        apparmor="DENIED" operation="open"
        profile="libvirt-c814c482-e1f0-4c47-ba9f-2b354f89d0e9"
        name="/var/lib/libvirt/images/example-ubuntu-eoan-data-nvme.qcow2"
        pid=1700 comm="qemu-system-x86" requested_mask="r" denied_mask="r"
        fsuid=64055 ouid=64055
    
    When virt_infra_security_driver is set to "apparmor" we add a new rule
    to allow VMs to access to NVMe drives. It's probaby better to have
    custom profile for the VM created with virt-aa-helper however I'm not an
    apparmor expert and this is just designed for dev work.
    
    For details on Apparmor integration with libvirt, see doco:
    https://gitlab.com/apparmor/apparmor/-/wikis/Libvirt
