### PR TITLE
fix boot order conflict on Debian

### DIFF
--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -4,7 +4,6 @@
   shell: >
     virt-install
     --import
-    --boot hd
     --connect {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     --cpu {{ virt_infra_cpu_model }}
     --controller type=scsi,model=virtio-scsi,index=0


### PR DESCRIPTION
Originally we told virt-install to boot from hard drive (--boot hd)
however as a part of commit bc99a15, "add disks in a clearer way, we
now specify a boot order when defining the disks.

On Debian, having both caused a conflict and the guests could not be
defined. This change removes the --boot option as we can now just depend
on the disk boot order.