### PR TITLE
pass kvmhost check when --limit set to "all"

### DIFF
--- a/tasks/validations.yml
+++ b/tasks/validations.yml
@@ -14,7 +14,7 @@
     - name: "Abort play when 'kvmhost' not specified in limits"
       assert:
         that:
-          - '"kvmhost" in ansible_limit'
+          - '"kvmhost" in ansible_limit or ansible_limit == "all"'
         fail_msg: "Specify 'kvmhost' and VMs with --limit option, e.g. --limit kvmhost,guests"
         quiet: true
       when:


### PR DESCRIPTION
The kvmhost must be included in the limit so that the guests can be
created. A check exists to make sure this is included, however if limit
is set to "all" it will also include kvmhost, so we should not fail in
this case (it's the same as excluding a limit).