### PR TITLE
remove snapshots and saved data when undefine vm

### DIFF
--- a/tasks/virt-remove.yml
+++ b/tasks/virt-remove.yml
@@ -3,6 +3,8 @@
   command: >
     virsh --connect {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     undefine {{ inventory_hostname }}
+    --managed-save
+    --snapshots-metadata
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']


### PR DESCRIPTION
When undefining a VM, if the guest has snapshots it will fail to be
deleted and cleaned up.

This patch passes the options to virsh to remove all saved data and
snapshots for the VM so taht it can be cleaned up.