### PR TITLE
add MTU support on libvirt and guest networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,10 +574,12 @@ virt_infra_ssh_pwauth: true
 #  - "bridge" type requires the bridge interface (e.g. br0) to already exist on KVM host
 #  - "ovs" type requires the OVS bridge interface (e.g. ovsbr0) to already exist on KVM host
 # "model" is also optional
+# "mtu" is also optional
 virt_infra_networks:
   - name: "default"
     type: "nat"
     model: "virtio"
+    mtu: 9000
 
 # Disk defaults, support various libvirt options
 # We generally don't set them though, and leave it to hypervisor default
@@ -616,6 +618,7 @@ virt_infra_host_image_path: "/var/lib/libvirt/images"
 # You can create and remove NAT networks on kvmhost (creating bridges not supported)
 # The 'default' network is the standard one shipped with libvirt
 # By default we don't remove any networks (empty absent list)
+# 'mtu' is optional
 virt_infra_host_networks:
   absent: []
   present:
@@ -624,6 +627,7 @@ virt_infra_host_networks:
       subnet: "255.255.255.0"
       dhcp_start: "192.168.112.2"
       dhcp_end: "192.168.112.254"
+      mtu: 9000
 
 # List of binaries to check for on kvmhost
 virt_infra_host_deps:

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -38,11 +38,11 @@
     --name {{ inventory_hostname }}
     {% for network in virt_infra_networks %}
     {% if network.type is defined and network.type == "bridge" %}
-    --network bridge={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}
+    --network bridge={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
     {% elif network.type is defined and network.type == "ovs" %}
-    --network network={{ network.name }},portgroup={{ network.portgroup }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}
+    --network network={{ network.name }},portgroup={{ network.portgroup }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
     {% else %}
-    --network network={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}
+    --network network={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
     {% endif %}
     {% endfor %}
     --noreboot

--- a/templates/virt-network.j2
+++ b/templates/virt-network.j2
@@ -13,6 +13,9 @@
     </nat>
   </forward>
   {% endif %}
+  {% if (item.mtu is defined and item.mtu) and (item.type is undefined or (item.type is defined and item.type != "ovs"))%}
+  <mtu size="{{ item.mtu }}"/>
+  {% endif %}
   {% if item.type is defined and item.type == "ovs" %}
   <virtualport type='openvswitch'/>
   <forward mode="bridge"/>


### PR DESCRIPTION
This patch allows you to set the MTU for libvirt networks on KVM host as
well as for guest interfaces.

Simply add the `mtu` option to your kvmhost network definitions and/or
your guest network interfaces definitions. When setting on a libvirt
host network and specifying an IP, that interface will get that MTU.

Also note that setting the MTU for an OVS host network is not supproted
by libvirt and will be ignored. However, setting an MTU for a guest
connected to an OVS network is supported.

Note that if you're connecting your guest to a bridge, the bridge on the
KVM host should also have been set to the same or higher MTU.