### PR TITLE
Add ability to run shell commands in guest disk

### DIFF
--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -124,6 +124,28 @@
   become: true
   delegate_to: "{{ groups['kvmhost'][0] }}"
 
+- name: Run custom shell commands in guest disk
+  command: >
+    virt-customize
+    -a {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
+    {% if virt_infra_disk_cmd is defined and virt_infra_disk_cmd %}
+    {% for cmd in virt_infra_disk_cmd %}
+    --run-command "{{ cmd }}"
+    {% endfor %}
+    {% endif %}
+  register: result_disk_cmd
+  retries: 10
+  delay: 2
+  until: result_disk_cmd is succeeded
+  become: true
+  when:
+    - inventory_hostname not in groups['kvmhost']
+    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - virt_infra_state != "undefined"
+    - virt_infra_disk_cmd is defined and virt_infra_disk_cmd
+    - not result_stat_boot.stat.exists or (result_stat_boot.stat.exists and (keep_boot is not defined or keep_boot is defined and not keep_boot))
+  delegate_to: "{{ groups['kvmhost'][0] }}"
+
 - name: Install cloud-init and qemu-guest-agent in guest disk
   command: >
     virt-customize


### PR DESCRIPTION
It might be useful to run commands on the boot disk of a guest before it
is launched. For example, to set a local mirror, or set a proxy, etc.

This is run as a part of the disk-create.yaml task, after the disk is
created and before cloud-init and qemu-guest-agent are installed.

Simply create a list of shell commands that you want to be run against a
machine, through the `virt_infra_disk_cmd` variable.

For example, to set the mirror to use on a Fedora box:

  virt_infra_disk_cmd:
    - dnf config-manager --save --setopt baseurl=http://path-to-mirror fedora
    - dnf config-manager --save --setopt baseurl=http://path-to-mirror-updates updates

Just make sure that it is valid shell commands and it will get run on
the disk as root. Note that the VM will have host networking and should
be able to get out to network to access the Internet if required.