### PR TITLE
get the path of vbmc for use with commands

### DIFF
--- a/tasks/validations.yml
+++ b/tasks/validations.yml
@@ -293,6 +293,16 @@
         - virt_infra_vbmc and virt_infra_vbmc_pip
       become: true
 
+    - name: "KVM host only: Find the path for virtualbmc"
+      shell: "which vbmc"
+      register: result_vbmc_path
+      when:
+        - inventory_hostname in groups['kvmhost']
+        - virt_infra_vbmc and virt_infra_vbmc_pip
+        - result_vbmc_pip is succeeded
+      run_once: true
+      changed_when: true
+
     - name: "KVM host only: Advise unable to install virtualbmc"
       set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to install virtualbmc with pip'] }}"

--- a/tasks/vbmc-create.yml
+++ b/tasks/vbmc-create.yml
@@ -2,7 +2,7 @@
 # Create any virtual BMC interfaces
 - name: Create virtual BMC
   shell: >
-    vbmc add {{ hostvars[item]['inventory_hostname'] }}
+    {{ result_vbmc_path.stdout }} add {{ hostvars[item]['inventory_hostname'] }}
     --libvirt-uri {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     --port {{ hostvars[item]['virt_infra_vbmc_port'] }}
     --username {{ hostvars[item]['vbmc_user'] | default('admin') }}
@@ -27,7 +27,7 @@
     - restart virtual bmc
 
 - name: Start virtual BMC
-  shell: "vbmc start {{ hostvars[item]['inventory_hostname'] }}"
+  shell: "{{ result_vbmc_path.stdout }} start {{ hostvars[item]['inventory_hostname'] }}"
   args:
     executable: /bin/bash
   become: true

--- a/tasks/vbmc-list.yml
+++ b/tasks/vbmc-list.yml
@@ -1,7 +1,7 @@
 ---
 # This is only run on KVM host
 - name: Get virtual BMC list
-  shell: vbmc list -f json --noindent |sed 's/Domain name/Name/g'
+  shell: "{{ result_vbmc_path.stdout }} list -f json --noindent |sed 's/Domain name/Name/g'"
   register: result_vbmc_list
   become: true
   args:

--- a/tasks/vbmc-remove.yml
+++ b/tasks/vbmc-remove.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove virtual BMC
-  shell: "vbmc delete {{ hostvars[item]['inventory_hostname'] }}"
+  shell: "{{ result_vbmc_path.stdout }} delete {{ hostvars[item]['inventory_hostname'] }}"
   args:
     executable: /bin/bash
   become: true


### PR DESCRIPTION
On distros like CentOS, /usr/local/bin is not in the sudoers path. This
means that all vbmc commands fail.

Rather than modify secure_path in /etc/sudoers, let's just get the path
and use that. This makes vbmc work, but also means the vbmc from the
user's path will be used.

Fixes #28 