### PR TITLE
fixed lookup

### DIFF
--- a/tasks/defaults-get.yml
+++ b/tasks/defaults-get.yml
@@ -9,7 +9,7 @@
 # These are only used if no keys are specified
 - name: Find SSH public keys on KVM host for cloud-init if none specified
   find:
-    paths: "{{ lookup('env','HOME') }}/.ssh/"
+    paths: "{{ ansible_user_dir }}/.ssh/"
     patterns: '*.pub'
   register: result_ssh_key_list
   changed_when: false
@@ -37,7 +37,7 @@
 # If no SSH keys found or specified, we create one, which requires ~/.ssh dir to exist
 - name: Ensure SSH dir exists if no SSH keys found or specified
   file:
-    path: "{{ lookup('env','HOME') }}/.ssh"
+    path: "{{ ansible_user_dir }}/.ssh"
     state: directory
   when:
     - inventory_hostname in groups['kvmhost']
@@ -46,7 +46,7 @@
 
 - name: Create SSH keypair if none found or specified
   openssh_keypair:
-    path: "{{ lookup('env','HOME') }}/.ssh/id_{{ virt_infra_ssh_key_type | default('rsa') }}-virt-infra-ansible"
+    path: "{{ ansible_user_dir }}/.ssh/id_{{ virt_infra_ssh_key_type | default('rsa') }}-virt-infra-ansible"
     size: "{{ virt_infra_ssh_key_size }}"
     type: "{{ virt_infra_ssh_key_type }}"
     state: present

--- a/tasks/hosts-add.yml
+++ b/tasks/hosts-add.yml
@@ -5,6 +5,7 @@
 # Or run this once only on one host with a look for all other hosts
 # Because serial is messy, I'm doing the latter
 # Thus, while this should be run against the kvmhost host, it will show one of your guests
+
 - name: Update /etc/hosts to resolve new VMs
   blockinfile:
     path: /etc/hosts
@@ -25,12 +26,12 @@
     create: true
     mode: 0600
     state: present
-    path: "{{ lookup('env','HOME') }}/.ssh/config"
+    path: "{{ hostvars[groups['kvmhost'][0]]['ansible_user_dir'] }}/.ssh/config"
     marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
     block: |-
       Host {{ hostvars[item]['vm_ip'] }} {{ hostvars[item]['inventory_hostname'] }}
         Hostname  {{ hostvars[item]['vm_ip'] }}
-        User {{ hostvars[item]['virt_infra_user'] | default(lookup('env', 'USER' )) }}
+        User {{ hostvars[item]['virt_infra_user'] | default( hostvars[groups['kvmhost'][0]]['ansible_user']) }}
       {% if hostvars[item]['virt_infra_ssh_keys'] is not defined %}
       {% if hostvars[groups['kvmhost'][0]].result_ssh_key_list.files is defined and hostvars[groups['kvmhost'][0]].result_ssh_key_list.files %}
       {% for file in hostvars[groups['kvmhost'][0]].result_ssh_key_list.files %}

--- a/tasks/hosts-remove.yml
+++ b/tasks/hosts-remove.yml
@@ -23,7 +23,7 @@
     create: true
     mode: 0600
     state: absent
-    path: "{{ lookup('env','HOME') }}/.ssh/known_hosts"
+    path: "{{ hostvars[groups['kvmhost'][0]]['ansible_user_dir'] }}/.ssh/known_hosts"
     marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
   become: false
   delegate_to: "{{ groups['kvmhost'][0] }}"
@@ -37,7 +37,7 @@
     create: true
     mode: 0600
     state: absent
-    path: "{{ lookup('env','HOME') }}/.ssh/config"
+    path: "{{ hostvars[groups['kvmhost'][0]]['ansible_user_dir'] }}/.ssh/config"
     marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
   become: false
   delegate_to: "{{ groups['kvmhost'][0] }}"

--- a/tasks/wait.yml
+++ b/tasks/wait.yml
@@ -16,7 +16,7 @@
     timeout: 600
   when:
     - inventory_hostname not in groups['kvmhost']
-    - virt_infra_state == "running"
+    - virt_infra_state is defined and virt_infra_state == "running"
   delegate_to: "{{ groups['kvmhost'][0] }}"
 
 - name: Get guest SSH fingerprints
@@ -28,7 +28,7 @@
   changed_when: false
   when:
     - inventory_hostname not in groups['kvmhost']
-    - virt_infra_state == "running"
+    - virt_infra_state is defined and virt_infra_state == "running"
 
 - name: Add guest fingerprint to SSH known_hosts
   blockinfile:

--- a/tasks/wait.yml
+++ b/tasks/wait.yml
@@ -35,7 +35,7 @@
     create: true
     mode: 0600
     state: present
-    path: "{{ lookup('env','HOME') }}/.ssh/known_hosts"
+    path: "{{ hostvars[groups['kvmhost'][0]]['ansible_user_dir'] }}/.ssh/known_hosts"
     marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
     block: |-
       {{ hostvars[item]['result_keyscan']['stdout'] }}
@@ -46,10 +46,3 @@
     - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "running"
   with_items: "{{ play_hosts }}"
   run_once: true
-
-- name: Wait for cloud-init to finish
-  wait_for:
-    path: /etc/cloud/cloud-init.disabled
-  when:
-    - inventory_hostname not in groups['kvmhost']
-    - virt_infra_state == "running"


### PR DESCRIPTION
fixes #35 
this MAY break other cases. I'm not sure, but  it should be sufficient.

Please especially take a look at the removal of cloud-init. This is the last task, nothing else (but a info) happens afterwards. This might be bad for playbooks which come after.

When using a remote host the task fails anyway, since you can't connect to a NAT network from outside the KVM Host.
the task can also just be set onto ingore_failure.