### PR TITLE
turn guest deps into variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,9 @@ I have tested the following guests successfully:
 So that we can configure the guest and get its IP, both cloud-init and
 qemu-guest-agent will be installed into you guest's image, just in case.
 
+This can be changed or overridden using the `virt_infra_guest_deps` variable,
+which is a list.
+
 Sysprep is also run on the guest image to make sure it's clean of things like
 old MAC addresses.
 
@@ -688,6 +691,11 @@ virt_infra_host_deps:
   - virsh
   - virt-customize
   - virt-sysprep
+
+# List of packages to install into guest image
+virt_infra_guest_deps:
+  - cloud-init
+  - qemu-guest-agent
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -126,3 +126,8 @@ virt_infra_host_deps:
   - virsh
   - virt-customize
   - virt-sysprep
+
+# Comma separated list of packages to install into guest disks
+virt_infra_guest_deps:
+  - cloud-init
+  - qemu-guest-agent

--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -149,7 +149,7 @@
     - not result_stat_boot.stat.exists or (result_stat_boot.stat.exists and (keep_boot is not defined or keep_boot is defined and not keep_boot))
   delegate_to: "{{ groups['kvmhost'][0] }}"
 
-- name: Install cloud-init and qemu-guest-agent in guest disk
+- name: Install required packages into guest disk
   command: >
     virt-customize
     -a {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
@@ -158,7 +158,7 @@
     --sm-credentials {{ virt_infra_sm_creds }}
     --sm-attach {{ virt_infra_sm_attach | default("auto") }}
     {% endif %}
-    --install qemu-guest-agent,cloud-init
+    --install {{ virt_infra_guest_deps | join(',') }}
   register: result_disk_deps
   retries: 10
   delay: 2
@@ -168,6 +168,7 @@
     - inventory_hostname not in groups['kvmhost']
     - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
     - virt_infra_state != "undefined"
+    - virt_infra_guest_deps is defined and virt_infra_guest_deps
     - not result_stat_boot.stat.exists or (result_stat_boot.stat.exists and (keep_boot is not defined or keep_boot is defined and not keep_boot))
     - not ((virt_infra_variant is defined and 'rhel' in virt_infra_variant) and (virt_infra_sm_creds is undefined or virt_infra_sm_creds is defined and not virt_infra_sm_creds))
   delegate_to: "{{ groups['kvmhost'][0] }}"

--- a/vars/rhel.yml
+++ b/vars/rhel.yml
@@ -1,0 +1,17 @@
+---
+# RHEL specific vars
+virt_infra_host_pkgs_kvm:
+  - "@virtualization-hypervisor"
+
+virt_infra_host_pkgs_deps:
+  - genisoimage
+  - libguestfs-tools-c
+  - libosinfo
+  - python3
+  - python3-libvirt
+  - python3-lxml
+  - python3-pip
+  - qemu-img
+  - virt-install
+
+virt_infra_security_driver: selinux


### PR DESCRIPTION
By default we make sure that cloud-init and qemu-guest-agent are
installed into the VM so that it can be configured on boot. If the image
already includes them, then this step can be skipped. Furthermore, you
might want to have different or additional packages installed.

This patch introduces a comma separated variable of
`virt_infra_guest_deps` which defaults to the existing values of
"cloud-init,qemu-guest-agent".

To skip installation of any packages, set this to an empty string in
your inventory, e.g.

  virt_infra_guest_deps: ""

If you want to install different packages then make a new list, e.g.:
  virt_infra_guest_deps: "cloud-init,qemu-guest-agent,vim,git,rsync"

As with all vars these can be at the host or group level.

This patch also includes vars/rhel.yml which was missing for RHEL hosts.