### PR TITLE
add support for network config via cloud-init

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ virt_infra_ssh_key_type: "rsa"
 # Whether to enable SSH password auth
 virt_infra_ssh_pwauth: true
 
+# Whether to use cloud-init to configure networking on guest
+virt_infra_network_config: false
+
 # Networks are a list, you can add more than one
 # "type" is optional, both "nat" and "bridge" are supported
 #  - "nat" is default type and should be a libvirt network

--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -137,12 +137,26 @@
     - virt_infra_state != "undefined"
   delegate_to: "{{ groups['kvmhost'][0] }}"
 
+- name: Create cloud init network-config for guest
+  template:
+    src: templates/network-config.j2
+    dest: "{{ result_tempdir.path }}/network-config"
+    mode: '0644'
+  become: true
+  when:
+    - inventory_hostname not in groups['kvmhost']
+    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - virt_infra_state != "undefined"
+    - virt_infra_network_config is defined and virt_infra_network_config
+  delegate_to: "{{ groups['kvmhost'][0] }}"
+
 - name: Make cloud-init iso for guest
   shell: >
     {{ hostvars[groups['kvmhost'][0]].virt_infra_mkiso_cmd | default(virt_infra_mkiso_cmd) }} -J -l -R -V "cidata" -iso-level 4
     -o {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso
     {{ result_tempdir.path }}/user-data
     {{ result_tempdir.path }}/meta-data
+    {% if virt_infra_network_config is defined and virt_infra_network_config %}{{ result_tempdir.path }}/network-config{% endif %}
   args:
     creates: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso"
     executable: /bin/bash

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -38,11 +38,11 @@
     --name {{ inventory_hostname }}
     {% for network in virt_infra_networks %}
     {% if network.type is defined and network.type == "bridge" %}
-    --network bridge={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
+    --network bridge={{ network.name }},mac={{ network.mac | default(('52:54:' + ("%02d" | format(loop.index0) |string)) | random_mac(seed=inventory_hostname)) }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
     {% elif network.type is defined and network.type == "ovs" %}
-    --network network={{ network.name }},portgroup={{ network.portgroup }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
+    --network network={{ network.name }},mac={{ network.mac | default(('52:54:' + ("%02d" | format(loop.index0) |string)) | random_mac(seed=inventory_hostname)) }},portgroup={{ network.portgroup }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
     {% else %}
-    --network network={{ network.name }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mac is defined and network.mac %},mac={{ network.mac }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
+    --network network={{ network.name }},mac={{ network.mac | default(('52:54:' + ("%02d" | format(loop.index0) |string)) | random_mac(seed=inventory_hostname)) }}{% if network.model is defined and network.model %},model={{ network.model }}{% endif %}{% if network.mtu is defined and network.mtu %},mtu.size={{ network.mtu }}{% endif %}
     {% endif %}
     {% endfor %}
     --noreboot

--- a/templates/network-config.j2
+++ b/templates/network-config.j2
@@ -1,0 +1,53 @@
+{% for network in virt_infra_networks %}
+{% if loop.index0 == 0 %}
+version: 2
+ethernets:
+{% endif %}
+  {{ network.device | default('eth' + (loop.index0 |string) )}}:
+    set-name: {{ network.device | default('eth' + (loop.index0 |string) ) }}
+    match:
+      macaddress: '{{ network.mac | default(('52:54:' + ("%02d" | format(loop.index0) |string)) | random_mac(seed=inventory_hostname)) }}'
+{% if network.mtu is defined and network.mtu %}
+    mtu: {{ network.mtu }}
+{% endif %}
+{% if network.addresses is defined and network.addresses %}
+    addresses:
+{% for address in network.addresses %}
+      - {{ address }}
+{% endfor %}
+{% else %}
+    dhcp4: {{ network.dhcp4 | default(true) }}
+    dhcp6: {{ network.dhcp6 | default(true) }}
+{% endif %}
+{% if network.gateway4 is defined and network.gateway4 %}
+    gateway4: {{ network.gateway4 }}
+{% endif %}
+{% if network.gateway6 is defined and network.gateway6 %}
+    gateway6: {{ network.gateway6 }}
+{% endif %}
+{% if network.nameservers.addresses is defined and network.nameservers.addresses %}
+    nameservers:
+      addresses:
+{% for ip in network.nameservers.addresses %}
+        - {{ ip }}
+{% endfor %}
+{% if network.nameservers.search is defined and network.nameservers.search %}
+      search:
+{% for domain in network.nameservers.search %}
+        - {{ domain }}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% if network.routes is defined and network.routes %}
+    routes:
+{% for route in network.routes %}
+{% if (route.to is defined and route.to) and (route.via is defined and route.via) %}
+      - to: {{ route.to }}
+        via: {{ route.via }}
+{% if route.metric is defined and route.metric %}
+        metric: {{ route.metric }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}

--- a/vars/centos.yml
+++ b/vars/centos.yml
@@ -10,6 +10,7 @@ virt_infra_host_pkgs_deps:
   - python3
   - python3-libvirt
   - python3-lxml
+  - python3-netaddr
   - python3-pip
   - qemu-img
   - virt-install

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -14,6 +14,7 @@ virt_infra_host_pkgs_deps:
   - libvirt-clients
   - python3-libvirt
   - python3-lxml
+  - python3-netaddr
   - python3-pip
   - qemu-utils
   - virtinst

--- a/vars/fedora.yml
+++ b/vars/fedora.yml
@@ -9,6 +9,7 @@ virt_infra_host_pkgs_deps:
   - libosinfo
   - python3-libvirt
   - python3-lxml
+  - python3-netaddr
   - python3-pip
   - qemu-img
   - virt-install

--- a/vars/opensuse.yml
+++ b/vars/opensuse.yml
@@ -11,6 +11,7 @@ virt_infra_host_pkgs_deps:
   - mkisofs
   - python3-libvirt-python
   - python3-lxml
+  - python3-netaddr
   - python3-pip
   - qemu-tools
   - virt-install

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -10,6 +10,7 @@ virt_infra_host_pkgs_deps:
   - python3
   - python3-libvirt
   - python3-lxml
+  - python3-netaddr
   - python3-pip
   - qemu-img
   - virt-install

--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -12,6 +12,7 @@ virt_infra_host_pkgs_deps:
   - libvirt-clients
   - python3-libvirt
   - python3-lxml
+  - python3-netaddr
   - python3-pip
   - qemu-utils
   - virtinst


### PR DESCRIPTION
This patchset enables support for basic network configuration v2 using
cloud-init. Currently only ethernet devices are supported (not bonds,
bridges or VLANs).

For details, see the cloud-init documentation:
https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html

As not all distros may support this, in order to activate network config
please enable the following variable:

  virt_infra_network_config: true

The network config is then populated with new optional network
configuration options for each VM's network interfaces, including:

 - device (string, to set the interface device name, e.g. eth0)
 - addresses (list)
 - gateway4 (string, IPv4 default gateway)
 - gateway6 (string, IPv6 default gateway)
 - nameservers (dict)
   - search (list of DNS domain search)
   - addresses (list of DNS servers)
 - routes (list of dicts)
   - to (key in dict, value is subnet to route to)
   - via (key in dict, value is gateway address/subnet)
   - metric (key in dict, int)

It is worth noting that none of the new options are actually required,
but here is an example:

  virt_infra_networks:
    - name: default
      device: eth0
      addresses:
        - 192.168.0.123/24
      gateway4: 192.168.0.1
      nameservers:
        search: [foo.local, bar.local]
        addresses: [8.8.8.8]
      routes:
        - to: 192.0.2.0/24
          via: 11.0.0.1
          metric: 3

The network config format requires specifying a network device to
configure which matches the actual interface. Unfortunately, there's no
way to always know that, as some distros will enable persistent names
and others won't.

For example, if we say "eth0" but the interfaces are actually "ens0"
instead, then the config will still be written to eth0 and therefore not
apply to ens0.

The solution to this is to rename the interface, so that it will match,
however in order to ensre we pick the exact interface we must match on
MAC address.

So, if a MAC address is not specified for the interface, this change
also adds a way to ensure that VMs can use network config reliably by
deterministically generating MAC addresses. As an ugly hack, it does
this based on the interface's place in the list of networks
(loop.index0), plus the standard random_mac method based on inventory
hostname, e.g.

  '{{ network.mac | default(('52:54:' + ("%02d" | format(loop.index0) |string)) | random_mac(seed=inventory_hostname)) }}'

If you have a better way to do this, I gladly accept patches!

Finally, the config must have a valid entry, it cannot be a blank file
and it cannot just have boilerplate like this:

  version: 2
  ethernets:

Furthermore, if we have a MAC address specified then it must match a
real interface on the box. Hence we generate them in the config if not
specified and ensure the VM gets the same addresses on the same
interfaces.

If either of these requirements are not met, cloud-init crashes and
fails to read any other config so the VM fails to boot successfully.