### PR TITLE
add support for multiple KVM hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ virt_infra_state: "running"
 virt_infra_autostart: "no"
 
 # Guest user, by default this will be set to the same user as KVM host user
-virt_infra_user: "{{ hostvars[groups['kvmhost'][0]].ansible_env.USER }}"
+virt_infra_user: "{{ hostvars[kvmhost].ansible_env.USER }}"
 
 # Password of default user (consider a vault if you need secure passwords)
 # No root password by default
@@ -70,8 +70,8 @@ virt_infra_disks:
 #   io: "{{ virt_infra_disk_io }}"
 #   cache: "{{ virt_infra_disk_cache }}"
 
-# Default distro is CentOS 7, override in guests or groups
-virt_infra_distro_image: "CentOS-7-x86_64-GenericCloud.qcow2"
+# Default distro is CentOS 8, override in guests or groups
+virt_infra_distro_image: "CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2"
 
 # Determine supported variants on your KVM host with command, "osinfo-query os"
 # This doesn't really make much difference to the guest, maybe slightly different bus
@@ -80,9 +80,9 @@ virt_infra_distro_image: "CentOS-7-x86_64-GenericCloud.qcow2"
 
 # These distro vars are here for reference and convenience
 virt_infra_distro: "centos"
-virt_infra_distro_release: "7"
-virt_infra_distro_image_url: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"
-virt_infra_distro_image_checksum_url: "https://cloud.centos.org/centos/7/images/sha256sum.txt"
+virt_infra_distro_release: "8"
+virt_infra_distro_image_url: "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2"
+virt_infra_distro_image_checksum_url: "https://cloud.centos.org/centos/8-stream/x86_64/images/CHECKSUM"
 
 ## KVM host related
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,8 +12,8 @@
   register: result_vbmcd_stop
   become: true
   changed_when: true
-  delegate_to: "{{ groups['kvmhost'][0] }}"
-  run_once: true
+  when:
+    - inventory_hostname in groups['kvmhost']
 
 - name: "Start virtualbmc daemon"
   service:
@@ -24,5 +24,5 @@
   register: result_vbmcd_start
   become: true
   changed_when: true
-  delegate_to: "{{ groups['kvmhost'][0] }}"
-  run_once: true
+  when:
+    - inventory_hostname in groups['kvmhost']

--- a/tasks/defaults-get.yml
+++ b/tasks/defaults-get.yml
@@ -15,7 +15,7 @@
   changed_when: false
   when:
     - inventory_hostname in groups['kvmhost']
-    - hostvars[groups['kvmhost'][0]].virt_infra_ssh_keys is not defined
+    - hostvars[inventory_hostname].virt_infra_ssh_keys is not defined
 
 - name: Read public SSH keys on KVM host if none specified
   command: "cat {{ item.path }}"
@@ -24,7 +24,7 @@
   changed_when: false
   when:
     - inventory_hostname in groups['kvmhost']
-    - hostvars[groups['kvmhost'][0]].virt_infra_ssh_keys is not defined
+    - hostvars[inventory_hostname].virt_infra_ssh_keys is not defined
 
 - name: Set SSH keys as KVM host default for cloud-init
   set_fact:
@@ -32,7 +32,7 @@
   with_items: "{{ result_ssh_keys.results }}"
   when:
     - inventory_hostname in groups['kvmhost']
-    - hostvars[groups['kvmhost'][0]].virt_infra_ssh_keys is not defined
+    - hostvars[inventory_hostname].virt_infra_ssh_keys is not defined
 
 # If no SSH keys found or specified, we create one, which requires ~/.ssh dir to exist
 - name: Ensure SSH dir exists if no SSH keys found or specified
@@ -41,7 +41,7 @@
     state: directory
   when:
     - inventory_hostname in groups['kvmhost']
-    - hostvars[groups['kvmhost'][0]].virt_infra_ssh_keys is not defined
+    - hostvars[inventory_hostname].virt_infra_ssh_keys is not defined
     - result_ssh_key_list.files | length == 0
 
 - name: Create SSH keypair if none found or specified
@@ -53,7 +53,7 @@
   register: result_ssh_key_gen
   when:
     - inventory_hostname in groups['kvmhost']
-    - hostvars[groups['kvmhost'][0]].virt_infra_ssh_keys is not defined
+    - hostvars[inventory_hostname].virt_infra_ssh_keys is not defined
     - result_ssh_key_list.files | length == 0
 
 - name: Set created SSH key as KVM host default for cloud-init
@@ -61,12 +61,12 @@
     virt_infra_ssh_keys: "{{ virt_infra_ssh_keys + [ result_ssh_key_gen.public_key ] }}"
   when:
     - inventory_hostname in groups['kvmhost']
-    - hostvars[groups['kvmhost'][0]].virt_infra_ssh_keys is not defined
+    - hostvars[inventory_hostname].virt_infra_ssh_keys is not defined
     - result_ssh_key_gen.public_key is defined and result_ssh_key_gen.public_key
 
 # Get timezone from KVM host to use as defaults for cloud-init
 # This is only used if no timezone is specified
-# Unfortunately can't use date from "{{ hostvars[groups['kvmhost'][0]].ansible_date_time.tz }}"
+# Unfortunately can't use date from "{{ hostvars[kvmhost].ansible_date_time.tz }}"
 # as it's an achronym which can't be resolved to country/city for cloud-init
 # Due to Ubuntu Bionic, can't use 'timedatectl -p Timezone --value show'
 - name: Get timezone from KVM host for cloud-init

--- a/tasks/defaults-set.yml
+++ b/tasks/defaults-set.yml
@@ -2,14 +2,14 @@
 # Set defaults for the guests based on the KVM host
 - name: Use KVM host architecture for VMs when not specified
   set_fact:
-    virt_infra_architecture: "{{ hostvars[groups['kvmhost'][0]].ansible_architecture }}"
+    virt_infra_architecture: "{{ hostvars[kvmhost].ansible_architecture }}"
   when:
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_architecture is not defined
 
 - name: Use KVM host domain for VMs when not specified
   set_fact:
-    virt_infra_domainname: "{{ hostvars[groups['kvmhost'][0]].ansible_domain }}"
+    virt_infra_domainname: "{{ hostvars[kvmhost].ansible_domain }}"
   when:
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_domainname is not defined

--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -8,12 +8,12 @@
 
 - name: Check if boot disk already exists
   stat:
-    path: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2"
+    path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2"
   register: result_stat_boot
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
+  delegate_to: "{{ kvmhost }}"
 
 - name: Check if boot disk is set to keep
   set_fact:
@@ -21,7 +21,7 @@
   with_items: "{{ virt_infra_disks }}"
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - item.name == "boot"
     - item.keep is defined and item.keep
 
@@ -33,71 +33,71 @@
     {% else %}
     create -f qcow2 -F qcow2 -b
     {% endif %}
-    {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ virt_infra_distro_image }}
-    {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2
+    {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ virt_infra_distro_image }}
+    {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2
   args:
-    creates: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
+    creates: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
   register: result_disk_create
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
     - item.name == "boot"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   with_items: "{{ virt_infra_disks }}"
 
 - name: Resize boot disk for VM
   command: >
     qemu-img
     resize
-    {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2
+    {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2
     {{ item.size | default(virt_infra_disk_size) }}G
   register: result_disk_resize
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
     - item.name == "boot"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   with_items: "{{ virt_infra_disks }}"
 
 - name: Create additional disks for VM
   command: >
     qemu-img create -f qcow2
-    {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2
+    {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2
     {{ item.size | default(virt_infra_disk_size) }}G
   args:
-    creates: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
+    creates: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
   register: result_disks_create
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
     - item.name != "boot"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   with_items: "{{ virt_infra_disks }}"
 
 # Due to the way NVME works with qemu (as args),
 # we need specific permissions on the image
 - name: Set permissions on NVMe disk images
   file:
-    path: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
-    owner: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_owner | default('root') }}"
-    group: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_group | default('qemu') }}"
-    mode: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_mode | default('0660') }}"
+    path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
+    owner: "{{ hostvars[kvmhost].virt_infra_host_image_owner | default('root') }}"
+    group: "{{ hostvars[kvmhost].virt_infra_host_image_group | default('qemu') }}"
+    mode: "{{ hostvars[kvmhost].virt_infra_host_image_mode | default('0660') }}"
     seuser: system_u
     serole: object_r
     setype: svirt_image_t
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
     - item.bus is defined and item.bus == "nvme"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   with_items: "{{ virt_infra_disks }}"
 
 ## Create cloudinit iso
@@ -109,9 +109,9 @@
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Create cloud init meta-data for guest
   template:
@@ -121,9 +121,9 @@
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Create cloud init user-data for guest
   template:
@@ -133,9 +133,9 @@
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Create cloud init network-config for guest
   template:
@@ -145,27 +145,27 @@
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
     - virt_infra_network_config is defined and virt_infra_network_config
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Make cloud-init iso for guest
   shell: >
-    {{ hostvars[groups['kvmhost'][0]].virt_infra_mkiso_cmd | default(virt_infra_mkiso_cmd) }} -J -l -R -V "cidata" -iso-level 4
-    -o {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso
+    {{ hostvars[kvmhost].virt_infra_mkiso_cmd | default(virt_infra_mkiso_cmd) }} -J -l -R -V "cidata" -iso-level 4
+    -o {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso
     {{ result_tempdir.path }}/user-data
     {{ result_tempdir.path }}/meta-data
     {% if virt_infra_network_config is defined and virt_infra_network_config %}{{ result_tempdir.path }}/network-config{% endif %}
   args:
-    creates: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso"
+    creates: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso"
     executable: /bin/bash
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Clean up temporary dir
   file:
@@ -175,12 +175,12 @@
     - inventory_hostname not in groups['kvmhost']
     - result_tempdir.path is defined
   become: true
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Run custom shell commands in guest disk
   command: >
     virt-customize
-    -a {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
+    -a {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
     {% if virt_infra_disk_cmd is defined and virt_infra_disk_cmd %}
     {% for cmd in virt_infra_disk_cmd %}
     --run-command '{{ cmd }}'
@@ -193,16 +193,16 @@
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
     - virt_infra_disk_cmd is defined and virt_infra_disk_cmd
     - not result_stat_boot.stat.exists or (result_stat_boot.stat.exists and (keep_boot is not defined or keep_boot is defined and not keep_boot))
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Install required packages into guest disk
   command: >
     virt-customize
-    -a {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
+    -a {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
     {% if virt_infra_sm_creds is defined and virt_infra_sm_creds %}
     --sm-register
     --sm-credentials {{ virt_infra_sm_creds }}
@@ -216,17 +216,17 @@
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
     - virt_infra_guest_deps is defined and virt_infra_guest_deps
     - not result_stat_boot.stat.exists or (result_stat_boot.stat.exists and (keep_boot is not defined or keep_boot is defined and not keep_boot))
     - not ((virt_infra_variant is defined and 'rhel' in virt_infra_variant) and (virt_infra_sm_creds is undefined or virt_infra_sm_creds is defined and not virt_infra_sm_creds))
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Remove RHEL registration
   command: >
     virt-customize
-    -a {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
+    -a {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
     {% if virt_infra_sm_creds is defined and virt_infra_sm_creds %}
     --sm-remove
     --sm-unregister
@@ -239,10 +239,10 @@
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_sm_creds is defined and virt_infra_sm_creds
     - virt_infra_state != "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Sysprep guest disk
   command: >
@@ -251,12 +251,12 @@
     {% if virt_infra_root_password is defined and virt_infra_root_password %}
     --root-password password:{{ virt_infra_root_password }}
     {% endif %}
-    --add {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
+    --add {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
   register: result_disk_sysprep
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - not result_stat_boot.stat.exists or (result_stat_boot.stat.exists and keep_boot is not defined or keep_boot is defined and not keep_boot)
     - virt_infra_state != "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"

--- a/tasks/disk-remove.yml
+++ b/tasks/disk-remove.yml
@@ -6,24 +6,24 @@
 # Only remove disks if the guest is not running and it's set to undefined
 - name: Remove guest disks
   file:
-    path: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
+    path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
     state: absent
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_running_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_running_vms.list_vms
     - item.keep is not defined or item.keep is defined and not item.keep
     - virt_infra_state == "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   with_items: "{{ virt_infra_disks }}"
 
 - name: Remove guest cloud-init ISO
   file:
-    path: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso"
+    path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso"
     state: absent
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_running_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_running_vms.list_vms
     - virt_infra_state == "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"

--- a/tasks/hosts-add.yml
+++ b/tasks/hosts-add.yml
@@ -10,41 +10,49 @@
   blockinfile:
     path: /etc/hosts
     state: present
-    marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
+    marker: "# {mark} {{ inventory_hostname }} managed by virt_infra Ansible playbook"
     block: |-
-      {{ hostvars[item]['vm_ip'] }} {{ hostvars[item]['inventory_hostname'] }}
+      {{ vm_ip }} {{ inventory_hostname }}
   become: true
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   when:
-    - hostvars[item]['vm_ip'] is defined and hostvars[item]['vm_ip']
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "running"
-  with_items: "{{ play_hosts }}"
-  run_once: true
+    - inventory_hostname not in groups['kvmhost']
+    - vm_ip is defined and vm_ip
+    - virt_infra_state | default(virt_infra_state) == "running"
+  throttle: 1
+#  with_items: "{{ play_hosts }}"
+#  run_once: true
 
 - name: Add host to SSH config
   blockinfile:
     create: true
     mode: 0600
     state: present
-    path: "{{ hostvars[groups['kvmhost'][0]].ansible_env.HOME }}/.ssh/config"
-    marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
+    path: "{{ hostvars[kvmhost].ansible_env.HOME }}/.ssh/config"
+    marker: "# {mark} {{ inventory_hostname }} managed by virt_infra Ansible playbook"
     block: |-
-      Host {{ hostvars[item]['vm_ip'] }} {{ hostvars[item]['inventory_hostname'] }}
-        Hostname  {{ hostvars[item]['vm_ip'] }}
-        User {{ hostvars[item]['virt_infra_user'] | default(hostvars[groups['kvmhost'][0]].ansible_env.USER) }}
-      {% if hostvars[item]['virt_infra_ssh_keys'] is not defined %}
-      {% if hostvars[groups['kvmhost'][0]].result_ssh_key_list.files is defined and hostvars[groups['kvmhost'][0]].result_ssh_key_list.files %}
-      {% for file in hostvars[groups['kvmhost'][0]].result_ssh_key_list.files %}
+      Host {{ vm_ip }} {{ inventory_hostname }}
+        Hostname  {{ vm_ip }}
+        User {{ virt_infra_user | default(hostvars[kvmhost].ansible_env.USER) }}
+      {% if virt_infra_ssh_keys is defined and virt_infra_ssh_keys %}
+      {% for key in virt_infra_ssh_keys %}
+      {{ "  IdentityFile " + key }}
+      {% endfor %}
+      {% elif virt_infra_ssh_keys is not defined or virt_infra_ssh_keys is defined and not virt_infra_ssh_keys %}
+      {% if hostvars[kvmhost].result_ssh_key_list.files is defined and hostvars[kvmhost].result_ssh_key_list.files %}
+      {% for file in hostvars[kvmhost].result_ssh_key_list.files %}
       {{ "  IdentityFile " + file.path.split('.pub')[0] }}
       {% endfor %}
-      {% elif hostvars[groups['kvmhost'][0]].result_ssh_key_gen.filename is defined and hostvars[groups['kvmhost'][0]].result_ssh_key_gen.filename %}
-      {{ "  IdentityFile " + hostvars[groups['kvmhost'][0]].result_ssh_key_gen.filename.split('.pub')[0] }}
+      {% elif hostvars[kvmhost].result_ssh_key_gen.filename is defined and hostvars[kvmhost].result_ssh_key_gen.filename %}
+      {{ "  IdentityFile " + hostvars[kvmhost].result_ssh_key_gen.filename.split('.pub')[0] }}
       {% endif %}
       {% endif %}
   become: false
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   when:
-    - hostvars[item]['vm_ip'] is defined and hostvars[item]['vm_ip']
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "running"
-  with_items: "{{ play_hosts }}"
-  run_once: true
+    - inventory_hostname not in groups['kvmhost']
+    - vm_ip is defined and vm_ip
+    - virt_infra_state | default(virt_infra_state) == "running"
+  throttle: 1
+#  with_items: "{{ play_hosts }}"
+#  run_once: true

--- a/tasks/hosts-remove.yml
+++ b/tasks/hosts-remove.yml
@@ -10,38 +10,44 @@
     create: true
     state: absent
     path: /etc/hosts
-    marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
+    marker: "# {mark} {{ inventory_hostname }} managed by virt_infra Ansible playbook"
   become: true
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   when:
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "undefined"
-  with_items: "{{ play_hosts }}"
-  run_once: true
+    - inventory_hostname not in groups['kvmhost']
+    - virt_infra_state | default(virt_infra_state) == "undefined"
+  throttle: 1
+#  with_items: "{{ play_hosts }}"
+#  run_once: true
 
 - name: Remove guests from SSH known_hosts
   blockinfile:
     create: true
     mode: 0600
     state: absent
-    path: "{{ hostvars[groups['kvmhost'][0]].ansible_env.HOME }}/.ssh/known_hosts"
-    marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
+    path: "{{ hostvars[kvmhost].ansible_env.HOME }}/.ssh/known_hosts"
+    marker: "# {mark} {{ inventory_hostname }} managed by virt_infra Ansible playbook"
   become: false
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   when:
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "undefined"
-  with_items: "{{ play_hosts }}"
-  run_once: true
+    - inventory_hostname not in groups['kvmhost']
+    - virt_infra_state | default(virt_infra_state) == "undefined"
+  throttle: 1
+#  with_items: "{{ play_hosts }}"
+#  run_once: true
 
 - name: Remove guests from SSH config
   blockinfile:
     create: true
     mode: 0600
     state: absent
-    path: "{{ hostvars[groups['kvmhost'][0]].ansible_env.HOME }}/.ssh/config"
-    marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
+    path: "{{ hostvars[kvmhost].ansible_env.HOME }}/.ssh/config"
+    marker: "# {mark} {{ inventory_hostname }} managed by virt_infra Ansible playbook"
   become: false
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   when:
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "undefined"
-  with_items: "{{ play_hosts }}"
-  run_once: true
+    - inventory_hostname not in groups['kvmhost']
+    - virt_infra_state | default(virt_infra_state) == "undefined"
+  throttle: 1
+#  with_items: "{{ play_hosts }}"
+#  run_once: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+- include_tasks: validations-initial.yml
 - include_tasks: validations.yml
 - include_tasks: defaults-get.yml
 - include_tasks: virt-list.yml
@@ -24,7 +25,7 @@
   debug:
     msg: item
   with_items:
-    - SSH key created at {{ hostvars[groups['kvmhost'][0]].result_ssh_key_gen.filename }}
+    - SSH key created at {{ result_ssh_key_gen.filename }}
   when:
     - inventory_hostname in groups['kvmhost']
-    - hostvars[groups['kvmhost'][0]].result_ssh_key_gen.filename is defined and hostvars[groups['kvmhost'][0]].result_ssh_key_gen.filename
+    - result_ssh_key_gen.filename is defined and result_ssh_key_gen.filename

--- a/tasks/net-create.yml
+++ b/tasks/net-create.yml
@@ -7,7 +7,6 @@
     name: "{{ item.name }}"
     xml: '{{ lookup("template", "templates/virt-network.j2") }}'
     uri: "{{ virt_infra_host_libvirt_url }}"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
   become: true
   with_items: "{{ virt_infra_host_networks.present }}"
   when:
@@ -20,7 +19,6 @@
     state: active
     name: "{{ item.name }}"
     uri: "{{ virt_infra_host_libvirt_url }}"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
   become: true
   with_items: "{{ virt_infra_host_networks.present }}"
   when:
@@ -33,7 +31,6 @@
     autostart: yes
     name: "{{ item.name }}"
     uri: "{{ virt_infra_host_libvirt_url }}"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
   become: true
   with_items: "{{ virt_infra_host_networks.present }}"
   when:

--- a/tasks/net-list.yml
+++ b/tasks/net-list.yml
@@ -25,7 +25,7 @@
   virt_net:
     command: facts
     name: "{{ item.name }}"
-    uri: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
+    uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
   register: result_libvirt_network
   become: true
   run_once: true
@@ -37,7 +37,7 @@
   virt_net:
     command: list_nets
     name: dummy
-    uri: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
+    uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
   register: result_libvirt_network_list
   become: true
   run_once: true

--- a/tasks/net-remove.yml
+++ b/tasks/net-remove.yml
@@ -4,7 +4,6 @@
   virt_net:
     state: inactive
     name: "{{ item.name }}"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
   with_items: "{{ virt_infra_host_networks.absent }}"
   when:
     - inventory_hostname in groups['kvmhost']
@@ -17,7 +16,6 @@
     command: undefine
     name: "{{ item.name }}"
     xml: '{{ lookup("template", "templates/virt-network.j2") }}'
-  delegate_to: "{{ groups['kvmhost'][0] }}"
   with_items: "{{ virt_infra_host_networks.absent }}"
   when:
     - inventory_hostname in groups['kvmhost']

--- a/tasks/validations-initial.yml
+++ b/tasks/validations-initial.yml
@@ -1,0 +1,65 @@
+---
+# Guests need to have a KVM host to deploy to
+# If it is not defined (or defined to empty string), we default to the first kvmhost in the kvmhost group.
+- name: "Guests: Ensure a KVM host is defined"
+  set_fact:
+    kvmhost: "{{ groups['kvmhost'][0] }}"
+  when:
+    - inventory_hostname not in groups['kvmhost']
+    - kvmhost is not defined or kvmhost is defined and not kvmhost
+  changed_when: false
+
+# Using fail or assert module removes the host from inventory on a task failure
+# We don't really want to do that, as we want to discover all problems at same time
+# If KVM host fails a task and is removed from inventory, then we can't run subsequent tests for guests
+# Thus we abort the play entirely straight away if KVM host is unreachable
+# Otherwise, we don't abort but instead set a variable when anything fails
+# We then print out any errors and end the play after the checks have completed
+# This means we can perform all checks for all hosts so you know all things you need to fix
+
+- name: Validate KVM host
+  block:
+    # The KVM host must be in the play_hosts, else we can't do anything
+    # We only know this host is defined as part of hostgroup, 'kvmhost'
+    # If --limit is not specified we run against every host, so we're fine
+    # When --limit is specified, it might be simply 'kvmhost,guest' or 'all' or even combinations, like 'all,!but-not-this-vm'
+    # Convert it to a list so we can easily check either 'kvmhost' or 'all' is there
+    # I think this is a bit cleaner than regex and should catch other combinations
+    - name: Convert --limit into a list for validation
+      set_fact:
+        limit_list: "{{ ansible_limit.split(',') }}"
+      delegate_to: "{{ groups['kvmhost'][0] }}"
+      run_once: true
+      when:
+        - ansible_limit is defined
+
+    - name: "Guests: Check that KVM host exists in inventory"
+      set_fact:
+        validations_failed: "{{ validations_failed|default([]) + ['KVM host ' + kvmhost + ' not in kvmhost group'] }}"
+      when:
+        - inventory_hostname not in groups['kvmhost']
+        - kvmhost not in groups['kvmhost']
+      changed_when: true
+
+    - name: "Guests: Check that KVM host is in limit"
+      set_fact:
+        validations_failed: "{{ validations_failed|default([]) + ['KVM host ' + kvmhost + ' not in limit, include --limit kvmhost option'] }}"
+      when:
+        - ansible_limit is defined
+        - inventory_hostname not in groups['kvmhost']
+        - 'kvmhost not in limit_list and "kvmhost" not in limit_list and "all" not in limit_list'
+      changed_when: true
+
+    - name: Validation failures
+      debug:
+        msg: "{{ validations_failed|default('nothing') }}"
+      when:
+        - validations_failed is defined and validations_failed
+      failed_when: true
+
+  rescue:
+    - debug:
+        msg: "Play aborted, see errors above"
+      changed_when: true
+
+    - meta: end_play

--- a/tasks/validations.yml
+++ b/tasks/validations.yml
@@ -1,40 +1,7 @@
 ---
-# Using fail or assert module removes the host from inventory on a task failure
-# We don't really want to do that, as we want to discover all problems at same time
-# If KVM host fails a task and is removed from inventory, then we can't run subsequent tests for guests
-# Thus we abort the play entirely straight away if KVM host is unreachable
-# Otherwise, we don't abort but instead set a variable when anything fails
-# We then print out any errors and end the play after the checks have completed
-# This means we can perform all checks for all hosts so you know all things you need to fix
-
-- name: Run all the validations
+# If the initial validations passed, it means we have valid KVM hosts and can continue
+- name: Run validations
   block:
-    # The KVM host must be in the play_hosts, else we can't do anything
-    # We only know this host is defined as part of hostgroup, 'kvmhost'
-    # If --limit is not specified we run against every host, so we're fine
-    # When --limit is specified, it might be simply 'kvmhost,guest' or 'all' or even combinations, like 'all,!but-not-this-vm'
-    # Convert it to a list so we can easily check either 'kvmhost' or 'all' is there
-    # I think this is a bit cleaner than regex and should catch other combinations
-    - name: Convert --limit into a list for validation
-      set_fact:
-        limit_list: "{{ ansible_limit.split(',') }}"
-      delegate_to: "{{ groups['kvmhost'][0] }}"
-      run_once: true
-      when:
-        - ansible_limit is defined
-
-    # This will fail here if we kvmhost isn't included in list else we can't perform other tests
-    - name: "Abort play when 'kvmhost' not specified in limits"
-      assert:
-        that:
-          - '"kvmhost" in limit_list or "all" in limit_list'
-        fail_msg: "Specify 'kvmhost' and VMs with --limit option, e.g. --limit kvmhost,guests"
-        quiet: true
-      when:
-        - ansible_limit is defined
-      delegate_to: "{{ groups['kvmhost'][0] }}"
-      run_once: true
-
     ## KVM host
     - name: "KVM host only: Get distro and network devices to validate guest configs"
       setup:
@@ -48,10 +15,11 @@
 
     - name: "Abort play if KVM host is unreachable"
       assert:
-        that: hostvars[groups['kvmhost'][0]].result_setup.unreachable is not defined
+        that: result_setup.unreachable is not defined
         fail_msg: "KVM host unreachable, please check inventory"
         quiet: true
-      run_once: true
+      when:
+        - inventory_hostname in groups['kvmhost']
 
     # Load distro specific vars here
     - name: "KVM host only: Load distro specific vars"
@@ -417,7 +385,7 @@
         - inventory_hostname in groups['kvmhost']
         - item.rc != 0
       changed_when: true
-      with_items: "{{ hostvars[groups['kvmhost'][0]].result_deps.results }}"
+      with_items: "{{ result_deps.results }}"
 
     - name: "KVM host only: Get list of supported os-variants"
       command: osinfo-query os
@@ -455,16 +423,16 @@
 
     - name: "KVM host: Test for distro images"
       stat:
-        path: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ virt_infra_distro_image }}"
+        path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ virt_infra_distro_image }}"
       register: result_base_image
-      delegate_to: "{{ groups['kvmhost'][0] }}"
+      delegate_to: "{{ kvmhost }}"
       when:
         - inventory_hostname not in groups['kvmhost']
 
     - name: "Guests: Check that distro disk image exists on KVM host"
       set_fact:
         validations_failed: "{{ validations_failed|default([]) + \
-        [ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) + '/' + \
+        [ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) + '/' + \
         virt_infra_distro_image + ' missing.{% if virt_infra_distro_image_url is defined and virt_infra_distro_image_url %} \
         Download from {{ virt_infra_distro_image_url }}{% endif %}'] }}"
       when:
@@ -478,9 +446,9 @@
       when:
         - inventory_hostname not in groups['kvmhost']
         - virt_infra_state != "undefined"
-        - hostvars[groups['kvmhost'][0]].virt_infra_host_networks.absent is defined
+        - hostvars[kvmhost].virt_infra_host_networks.absent is defined
         - virt_infra_networks | selectattr('name','equalto', item.name) | list | length != 0
-      with_items: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_networks.absent }}"
+      with_items: "{{ hostvars[kvmhost].virt_infra_host_networks.absent }}"
       changed_when: true
 
     - name: "Guests: Check required network is present"
@@ -490,8 +458,8 @@
         - inventory_hostname not in groups['kvmhost']
         - virt_infra_state != "undefined"
         - item.type is not defined or (item.type is defined and item.type != "bridge")
-        - hostvars[groups['kvmhost'][0]].virt_infra_host_networks.present is defined
-        - hostvars[groups['kvmhost'][0]].virt_infra_host_networks.present | selectattr('name','equalto', item.name) | list | length == 0
+        - hostvars[kvmhost].virt_infra_host_networks.present is defined
+        - hostvars[kvmhost].virt_infra_host_networks.present | selectattr('name','equalto', item.name) | list | length == 0
       with_items: "{{ virt_infra_networks }}"
       changed_when: true
 
@@ -501,10 +469,10 @@
       when:
         - inventory_hostname not in groups['kvmhost']
         - virt_infra_state != "undefined"
-        - hostvars[groups['kvmhost'][0]].virt_infra_host_networks.present is defined
+        - hostvars[kvmhost].virt_infra_host_networks.present is defined
         - item.type is defined and item.type == "ovs"
         - item.bridge_dev is not defined
-      with_items: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_networks.present }}"
+      with_items: "{{ hostvars[kvmhost].virt_infra_host_networks.present }}"
       changed_when: true
 
     - name: "Guests: Check if required bridge interfaces exist on KVM host"
@@ -513,7 +481,7 @@
       when:
         - inventory_hostname not in groups['kvmhost']
         - item.type is defined and item.type == "bridge"
-        - item.name not in hostvars[groups['kvmhost'][0]].ansible_interfaces
+        - item.name not in hostvars[kvmhost].ansible_interfaces
       with_items: "{{ virt_infra_networks }}"
       changed_when: true
 
@@ -531,9 +499,9 @@
         validations_failed: "{{ validations_failed|default([]) + [ virt_infra_variant + ' not supported by KVM host, run: sudo osinfo-query os'] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
-        - hostvars[groups['kvmhost'][0]].result_osinfo.stdout is defined
+        - hostvars[kvmhost].result_osinfo.stdout is defined
         - virt_infra_variant is defined
-        - hostvars[groups['kvmhost'][0]].result_osinfo.stdout is not search(virt_infra_variant + " ")
+        - hostvars[kvmhost].result_osinfo.stdout is not search(virt_infra_variant + " ")
       changed_when: true
 
     - name: "Guests: Check that existing vbmc port and name match"
@@ -542,9 +510,9 @@
       when:
         - inventory_hostname not in groups['kvmhost']
         - virt_infra_vbmc_port is defined
-        - hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout is defined and hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout
+        - hostvars[kvmhost].result_vbmc_list.stdout is defined and hostvars[kvmhost].result_vbmc_list.stdout
         - item.Name == inventory_hostname and item.Port |string != virt_infra_vbmc_port |string
-      with_items: "{{ hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout }}"
+      with_items: "{{ hostvars[kvmhost].result_vbmc_list.stdout }}"
       changed_when: true
 
     - name: "Guests: Check that vbmc port does not conflict with existing"
@@ -553,9 +521,9 @@
       when:
         - inventory_hostname not in groups['kvmhost']
         - virt_infra_vbmc_port is defined
-        - hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout is defined and hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout
+        - hostvars[kvmhost].result_vbmc_list.stdout is defined and hostvars[kvmhost].result_vbmc_list.stdout
         - item.Name != inventory_hostname and item.Port == virt_infra_vbmc_port
-      with_items: "{{ hostvars[groups['kvmhost'][0]].result_vbmc_list.stdout }}"
+      with_items: "{{ hostvars[kvmhost].result_vbmc_list.stdout }}"
       changed_when: true
 
     # - name: "Check that disks don't already exist for guest"

--- a/tasks/vbmc-create.yml
+++ b/tasks/vbmc-create.yml
@@ -2,11 +2,11 @@
 # Create any virtual BMC interfaces
 - name: Create virtual BMC
   shell: >
-    {{ hostvars[groups['kvmhost'][0]].result_vbmc_path.stdout }} add {{ hostvars[item]['inventory_hostname'] }}
-    --libvirt-uri {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
-    --port {{ hostvars[item]['virt_infra_vbmc_port'] }}
-    --username {{ hostvars[item]['vbmc_user'] | default('admin') }}
-    --password {{ hostvars[item]['vbmc_password'] | default('password') }}
+    {{ hostvars[kvmhost].result_vbmc_path.stdout }} add {{ inventory_hostname }}
+    --libvirt-uri {{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
+    --port {{ virt_infra_vbmc_port }}
+    --username {{ vbmc_user | default('admin') }}
+    --password {{ vbmc_password | default('password') }}
   args:
     executable: /bin/bash
   become: true
@@ -15,19 +15,17 @@
   delay: 2
   until: result_vbmc_create is succeeded
   when:
-    - hostvars[item]['inventory_hostname'] not in groups['kvmhost']
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) != "undefined"
-    - hostvars[item]['virt_infra_vbmc_port'] is defined and hostvars[item]['virt_infra_vbmc_port']
-    - hostvars[groups["kvmhost"][0]].virt_infra_vbmc is defined and hostvars[groups["kvmhost"][0]].virt_infra_vbmc or virt_infra_vbmc
-    - hostvars[groups["kvmhost"][0]].result_vbmc_list.stdout is defined and hostvars[item]['inventory_hostname'] not in hostvars[groups["kvmhost"][0]].result_vbmc_list.stdout
-  delegate_to: "{{ groups['kvmhost'][0] }}"
-  with_items: "{{ play_hosts }}"
-  run_once: true
+    - inventory_hostname not in groups['kvmhost']
+    - virt_infra_state | default(virt_infra_state) != "undefined"
+    - virt_infra_vbmc_port is defined and virt_infra_vbmc_port
+    - hostvars[kvmhost].virt_infra_vbmc is defined and hostvars[kvmhost].virt_infra_vbmc or virt_infra_vbmc
+    - hostvars[kvmhost].result_vbmc_list.stdout is defined and inventory_hostname not in hostvars[kvmhost].result_vbmc_list.stdout
+  delegate_to: "{{ kvmhost }}"
   notify:
     - restart virtual bmc
 
 - name: Start virtual BMC
-  shell: "set -o pipefail && {{ hostvars[groups['kvmhost'][0]].result_vbmc_path.stdout }} start {{ hostvars[item]['inventory_hostname'] }}"
+  shell: "set -o pipefail && {{ hostvars[kvmhost].result_vbmc_path.stdout }} start {{ inventory_hostname }}"
   args:
     executable: /bin/bash
   become: true
@@ -37,11 +35,10 @@
   until: result_vbmc_start is succeeded
   changed_when: false
   when:
-    - hostvars[item]['inventory_hostname'] not in groups['kvmhost']
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) != "undefined"
-    - hostvars[item]['virt_infra_vbmc_port'] is defined and hostvars[item]['virt_infra_vbmc_port']
-    - hostvars[groups["kvmhost"][0]].virt_infra_vbmc is defined and hostvars[groups["kvmhost"][0]].virt_infra_vbmc or virt_infra_vbmc
-  delegate_to: "{{ groups['kvmhost'][0] }}"
-  with_items: "{{ play_hosts }}"
+    - inventory_hostname not in groups['kvmhost']
+    - virt_infra_state | default(virt_infra_state) != "undefined"
+    - virt_infra_vbmc_port is defined and virt_infra_vbmc_port
+    - hostvars[kvmhost].virt_infra_vbmc is defined and hostvars[kvmhost].virt_infra_vbmc or virt_infra_vbmc
+  delegate_to: "{{ kvmhost }}"
 
 - meta: flush_handlers

--- a/tasks/vbmc-list.yml
+++ b/tasks/vbmc-list.yml
@@ -1,12 +1,12 @@
 ---
 # This is only run on KVM host
 - name: Get virtual BMC list
-  shell: "set -o pipefail && {{ hostvars[groups['kvmhost'][0]].result_vbmc_path.stdout }} list -f json --noindent |sed 's/Domain name/Name/g'"
+  shell: "set -o pipefail && {{ result_vbmc_path.stdout }} list -f json --noindent |sed 's/Domain name/Name/g'"
   register: result_vbmc_list
   become: true
   args:
     executable: /bin/bash
   when:
     - inventory_hostname in groups['kvmhost']
-    - hostvars[groups["kvmhost"][0]].virt_infra_vbmc is defined and hostvars[groups["kvmhost"][0]].virt_infra_vbmc or virt_infra_vbmc
+    - virt_infra_vbmc is defined and virt_infra_vbmc
   changed_when: false

--- a/tasks/vbmc-remove.yml
+++ b/tasks/vbmc-remove.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove virtual BMC
-  shell: "set -o pipefail && {{ hostvars[groups['kvmhost'][0]].result_vbmc_path.stdout }} delete {{ hostvars[item]['inventory_hostname'] }}"
+  shell: "set -o pipefail && {{ hostvars[kvmhost].result_vbmc_path.stdout }} delete {{ inventory_hostname }}"
   args:
     executable: /bin/bash
   become: true
@@ -9,14 +9,12 @@
   delay: 2
   until: result_vbmc_remove is succeeded
   when:
-    - hostvars[item]['inventory_hostname'] not in groups['kvmhost']
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "undefined"
-    - hostvars[item]['virt_infra_vbmc_port'] is defined and hostvars[item]['virt_infra_vbmc_port']
-    - hostvars[groups["kvmhost"][0]].virt_infra_vbmc is defined and hostvars[groups["kvmhost"][0]].virt_infra_vbmc or virt_infra_vbmc
-    - hostvars[groups["kvmhost"][0]].result_vbmc_list is defined and hostvars[item]['inventory_hostname'] in hostvars[groups["kvmhost"][0]].result_vbmc_list.stdout
-  delegate_to: "{{ groups['kvmhost'][0] }}"
-  with_items: "{{ play_hosts }}"
-  run_once: true
+    - inventory_hostname not in groups['kvmhost']
+    - virt_infra_state | default(virt_infra_state) == "undefined"
+    - virt_infra_vbmc_port is defined and virt_infra_vbmc_port
+    - hostvars[kvmhost].virt_infra_vbmc is defined and hostvars[kvmhost].virt_infra_vbmc or virt_infra_vbmc
+    - hostvars[kvmhost].result_vbmc_list is defined and inventory_hostname in hostvars[kvmhost].result_vbmc_list.stdout
+  delegate_to: "{{ kvmhost }}"
   notify:
     - restart virtual bmc
 

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -4,17 +4,17 @@
   shell: >
     set -o pipefail && virt-install
     --import
-    --connect {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
+    --connect {{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     --cpu {{ virt_infra_cpu_model }}
     --controller type=scsi,model=virtio-scsi,index=0
     {% set scsi_disk_count = [] %}
     {% set scsi_controller_count = [] %}
     {% for disk in virt_infra_disks %}
     {% if disk.bus is defined and disk.bus == "nvme" %}
-    --qemu-commandline='-drive file={{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ disk.name }}.qcow2,format=qcow2,if=none,id={{ disk.name | upper }}'
+    --qemu-commandline='-drive file={{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ disk.name }}.qcow2,format=qcow2,if=none,id={{ disk.name | upper }}'
     --qemu-commandline='-device nvme,drive={{ disk.name | upper }},serial={{ disk.name }}'
     {% else %}
-    --disk {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ disk.name }}.qcow2,serial={{ disk.name }},{% if disk.name == "boot" %}boot_order=1,{% endif %}format=qcow2,bus={{ disk.bus | default(virt_infra_disk_bus) }}{% if disk.cache is defined and disk.cache %},cache={{ disk.cache }}{% endif %}{% if disk.io is defined and disk.io %},io={{ disk.io }}{% endif %}
+    --disk {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ disk.name }}.qcow2,serial={{ disk.name }},{% if disk.name == "boot" %}boot_order=1,{% endif %}format=qcow2,bus={{ disk.bus | default(virt_infra_disk_bus) }}{% if disk.cache is defined and disk.cache %},cache={{ disk.cache }}{% endif %}{% if disk.io is defined and disk.io %},io={{ disk.io }}{% endif %}
     {% endif %}
     {% if (disk.bus is defined and disk.bus == "scsi" or disk.bus is undefined) and ( disk.ssd is defined and disk.ssd ) %}
     --qemu-commandline='-set device.scsi{{ scsi_controller_count | length }}-0-0-{{ scsi_disk_count | length }}.rotation_rate=1'
@@ -31,7 +31,7 @@
     {% if scsi_disk_count | length > 3  %}
     --controller type=scsi,model=virtio-scsi,index={{ ( scsi_controller_count | length ) + 1 }}
     {% endif %}
-    --disk {{ hostvars[groups['kvmhost'][0]].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso,device=cdrom,bus=scsi,format=iso
+    --disk {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso,device=cdrom,bus=scsi,format=iso
     --channel unix,target_type=virtio,name=org.qemu.guest_agent.0
     --graphics spice
     --machine {{ virt_infra_machine_type }}
@@ -65,9 +65,9 @@
   until: result_vm_create is succeeded
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state != "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   args:
     executable: /bin/bash
 
@@ -75,9 +75,9 @@
 - name: Set state of VM
   virt:
     name: "{{ inventory_hostname }}"
-    state: "{{ 'destroyed' if ( virt_infra_state == 'undefined' or (virt_infra_state == 'shutdown' and inventory_hostname in inventory_hostname not in hostvars[groups['kvmhost'][0]].result_running_vms.list_vms)) else virt_infra_state }}"
+    state: "{{ 'destroyed' if ( virt_infra_state == 'undefined' or (virt_infra_state == 'shutdown' and inventory_hostname in inventory_hostname not in hostvars[kvmhost].result_running_vms.list_vms)) else virt_infra_state }}"
     autostart: "{{ virt_infra_autostart }}"
-    uri: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
+    uri: "{{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
   become: true
   register: result_vm_state
   retries: 30
@@ -85,8 +85,8 @@
   until: result_vm_state is succeeded
   when:
     - inventory_hostname not in groups['kvmhost']
-    - not (virt_infra_state == "undefined" and inventory_hostname not in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms)
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+    - not (virt_infra_state == "undefined" and inventory_hostname not in hostvars[kvmhost].result_all_vms.list_vms)
+  delegate_to: "{{ kvmhost }}"
 
 # Wait for network so we can get the IP to log in
 # Do this for all VMs, in case they already existed and IP has changed
@@ -94,7 +94,7 @@
   shell: >
     set -o pipefail ;
     virsh
-    --connect {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
+    --connect {{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     domifaddr
     --source agent
     {{ inventory_hostname }}
@@ -110,7 +110,7 @@
   retries: 30
   delay: 10
   become: true
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   when:
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_state == "running"

--- a/tasks/virt-list.yml
+++ b/tasks/virt-list.yml
@@ -21,7 +21,7 @@
 - name: Get list of all VMs
   virt:
     command: list_vms
-    uri: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
+    uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
   register: result_all_vms
   become: true
   when:
@@ -31,7 +31,7 @@
   virt:
     command: list_vms
     state: running
-    uri: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
+    uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
   register: result_running_vms
   become: true
   when:
@@ -40,7 +40,7 @@
 - name: Get info on all VMs
   virt:
     command: info
-    uri: "{{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
+    uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
   register: result_info_vms
   become: true
   when:

--- a/tasks/virt-remove.yml
+++ b/tasks/virt-remove.yml
@@ -1,16 +1,16 @@
 ---
 - name: Undefine VM
   command: >
-    virsh --connect {{ hostvars[groups['kvmhost'][0]].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
+    virsh --connect {{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     undefine {{ inventory_hostname }}
     --managed-save
     --snapshots-metadata
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']
-    - inventory_hostname in hostvars[groups['kvmhost'][0]].result_all_vms.list_vms
+    - inventory_hostname in hostvars[kvmhost].result_all_vms.list_vms
     - virt_infra_state == "undefined"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   register: result_undefine
   retries: 30
   delay: 2

--- a/tasks/wait.yml
+++ b/tasks/wait.yml
@@ -17,13 +17,13 @@
   when:
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_state is defined and virt_infra_state == "running"
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
 
 - name: Get guest SSH fingerprints
   shell: "set -o pipefail && ssh-keyscan {{ inventory_hostname }} {{ vm_ip }} | sort"
   args:
     executable: /bin/bash
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   register: result_keyscan
   changed_when: false
   when:
@@ -35,17 +35,19 @@
     create: true
     mode: 0600
     state: present
-    path: "{{ hostvars[groups['kvmhost'][0]].ansible_env.HOME }}/.ssh/known_hosts"
-    marker: "# {mark} {{ hostvars[item]['inventory_hostname'] }} managed by virt_infra Ansible playbook"
+    path: "{{ hostvars[kvmhost].ansible_env.HOME }}/.ssh/known_hosts"
+    marker: "# {mark} {{ inventory_hostname }} managed by virt_infra Ansible playbook"
     block: |-
-      {{ hostvars[item]['result_keyscan']['stdout'] }}
+      {{ result_keyscan.stdout }}
   become: false
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   when:
-    - hostvars[item]['result_keyscan']['stdout'] is defined and hostvars[item]['result_keyscan']['stdout']
-    - hostvars[item]['virt_infra_state'] | default(virt_infra_state) == "running"
-  with_items: "{{ play_hosts }}"
-  run_once: true
+    - inventory_hostname not in groups['kvmhost']
+    - result_keyscan.stdout is defined and result_keyscan.stdout
+    - virt_infra_state | default(virt_infra_state) == "running"
+  throttle: 1
+#  with_items: "{{ play_hosts }}"
+#  run_once: true
 
 # This is not using wait_for module with path option anymore because it doesn't
 # work when kvmhost is remote
@@ -55,7 +57,7 @@
   retries: 60
   delay: 2
   until: result_wait_cloudinit is succeeded
-  delegate_to: "{{ groups['kvmhost'][0] }}"
+  delegate_to: "{{ kvmhost }}"
   when:
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_state == "running"

--- a/templates/user-data.j2
+++ b/templates/user-data.j2
@@ -2,22 +2,22 @@
 # Set the default user
 system_info:
   default_user:
-    name: {{ virt_infra_user | default(hostvars[groups['kvmhost'][0]].ansible_env.USER) }}
+    name: {{ virt_infra_user | default(hostvars[kvmhost].ansible_env.USER) }}
 
 # Unlock the default user
 chpasswd:
   list: |
-     {{ virt_infra_user | default(hostvars[groups['kvmhost'][0]].ansible_env.USER) }}:{{ virt_infra_password | default(virt_infra_password) }}
+     {{ virt_infra_user | default(hostvars[kvmhost].ansible_env.USER) }}:{{ virt_infra_password | default(virt_infra_password) }}
   expire: False
 
 # System settings
 resize_rootfs: True
 ssh_pwauth: "{{ virt_infra_ssh_pwauth | default(True) }}"
 ssh_authorized_keys:
-{% for key in virt_infra_ssh_keys | default(hostvars[groups['kvmhost'][0]].virt_infra_ssh_keys, true) %}
+{% for key in virt_infra_ssh_keys | default(hostvars[kvmhost].virt_infra_ssh_keys, true) %}
   - {{ key }}
 {% endfor %}
-timezone: {{ virt_infra_timezone | default(hostvars[groups['kvmhost'][0]].virt_infra_timezone, true) }}
+timezone: {{ virt_infra_timezone | default(hostvars[kvmhost].virt_infra_timezone, true) }}
 {% if virt_infra_root_password is defined and virt_infra_root_password %}
 disable_root: false
 {% endif %}


### PR DESCRIPTION
Originally this role was only designed to run on a single host, but it
seems useful to be able to use the one inventory across multiple KVM
hosts.

This change introduces the ability to specify multiple KVM hosts in the
kvmhost group. To do so, add hosts to the `kvmhost` group in your
kvmhost inventory.

For example, here we specify three KVM hosts.

---
kvmhost:
  hosts:
    kvmhost1:
    kvmhost2:
    kvmhost3:
  vars:
    ansible_python_interpreter: /usr/bin/python3
    virt_infra_host_networks:
      absent: []
      present:
        - name: "default"
          ip_address: "192.168.112.1"
          subnet: "255.255.255.0"
          dhcp_start: "192.168.112.2"
          dhcp_end: "192.168.112.254"

To have a VM land on a specific KVM host, you must add the variable
`kvmhost` with a string that matches a KVM host from the `kvmhost`
group.

For example, six CentOS and six Fedora hosts across three KVM hosts:

---
simple:
  hosts:
    simple-centos-[1:2]:
      kvmhost: kvmhost1
    simple-centos-[3:4]:
      kvmhost: kvmhost2
    simple-centos-[5:6]:
      kvmhost: kvmhost3
    simple-fedora-[1:2]:
      kvmhost: kvmhost1
    simple-fedora-[3:4]:
      kvmhost: kvmhost2
    simple-fedora-[5:6]:
      kvmhost: kvmhost3
  vars:
    ansible_python_interpreter: /usr/libexec/platform-python
    virt_infra_distro_image: "CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2"

If no kvmhost is specified for a VM it will default to the first KVM
host in the `kvmhost` group (i.e. kvmhost[0]) which matches the original
behaviour for the role.

Validation checks have been updated to make sure that all of the KVM
hosts are valid and that any specified KVM host for a VM is in the
`kvmhost` group.

To group VMs on certain KVM hosts, consider making child groups and
specify kvmhost at the child group level.

For example, those CentOS and Fedora hosts again:

---
simple:
  hosts:
    simple-centos-[1:6]:
    simple-fedora-[1:6]:
  vars:
    ansible_python_interpreter: /usr/libexec/platform-python
    virt_infra_distro_image: "CentOS-Stream-GenericCloud-8-20210603.0.x86_64.qcow2"
  children:
    simple_kvmhost1:
      hosts:
        simple-centos-[1:2]:
        simple-fedora-[1:2]:
      vars:
        kvmhost: kvmhost1
    simple_kvmhost2:
      hosts:
        simple-centos-[3:4]:
        simple-fedora-[3:4]:
      vars:
        kvmhost: kvmhost2
    simple_kvmhost3:
      hosts:
        simple-centos-[5:6]:
        simple-fedora-[5:6]:
      vars:
        kvmhost: kvmhost3

Closes #37