### PR TITLE
Fix using libvirt >= v7.7.0

### DIFF
--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -47,7 +47,7 @@
     {% endfor %}
     --noreboot
     --noautoconsole
-    --events on_poweroff=preserve,on_reboot=restart
+    --events on_reboot=restart
     --os-type linux
     {% if virt_infra_variant is defined and virt_infra_variant %}
     --os-variant {{ virt_infra_variant }}


### PR DESCRIPTION
Remove `on_poweroff=preserve` as it has been forbidden in libvirt v7.7.0.