### PR TITLE
support graphics server option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,9 @@ virt_infra_cpus_max: "{{ virt_infra_cpus }}"
 virt_infra_cpu_model: "host-passthrough"
 virt_infra_machine_type: "q35"
 
+# What graphics server to use, spice or vnc
+virt_infra_graphics: spice
+
 # SSH keys are a list, you can add more than one
 # If not specified, we default to all public keys on KVM host
 virt_infra_ssh_keys: []

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -33,7 +33,7 @@
     {% endif %}
     --disk {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso,device=cdrom,bus=scsi,format=iso
     --channel unix,target_type=virtio,name=org.qemu.guest_agent.0
-    --graphics spice
+    --graphics {{ virt_infra_graphics }}
     --machine {{ virt_infra_machine_type }}
     --name {{ inventory_hostname }}
     {% for network in virt_infra_networks %}


### PR DESCRIPTION
Currently this defaults to spice however some clients may not support it, so make this configurable.

New option can be vnc or spice, defaults to the latter.

  virt_infra_graphics: spice