### PR TITLE
Add vars to add .ssh/config and /etc/hosts only optionally

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,3 +137,9 @@ virt_infra_host_deps:
 virt_infra_guest_deps:
   - cloud-init
   - qemu-guest-agent
+
+# Automatically add entries to /etc/hosts on the kvmhost
+virt_infra_add_etc_hosts: true
+
+# Automatically add entries to $HOME/.ssh/config on the kvmhost
+virt_infra_add_ssh_config: true

--- a/tasks/hosts-add.yml
+++ b/tasks/hosts-add.yml
@@ -16,7 +16,7 @@
   become: true
   delegate_to: "{{ kvmhost }}"
   when:
-    - virt_infra_add_etc_hosts
+    - virt_infra_add_etc_hosts | default(virt_infra_add_etc_hosts) | bool
     - inventory_hostname not in groups['kvmhost']
     - vm_ip is defined and vm_ip
     - virt_infra_state | default(virt_infra_state) == "running"
@@ -47,7 +47,7 @@
   become: false
   delegate_to: "{{ kvmhost }}"
   when:
-    - virt_infra_add_ssh_config
+    - virt_infra_add_ssh_config | default(virt_infra_add_ssh_config) | bool
     - inventory_hostname not in groups['kvmhost']
     - vm_ip is defined and vm_ip
     - virt_infra_state | default(virt_infra_state) == "running"

--- a/tasks/hosts-add.yml
+++ b/tasks/hosts-add.yml
@@ -16,6 +16,7 @@
   become: true
   delegate_to: "{{ kvmhost }}"
   when:
+    - virt_infra_add_etc_hosts
     - inventory_hostname not in groups['kvmhost']
     - vm_ip is defined and vm_ip
     - virt_infra_state | default(virt_infra_state) == "running"
@@ -46,6 +47,7 @@
   become: false
   delegate_to: "{{ kvmhost }}"
   when:
+    - virt_infra_add_ssh_config
     - inventory_hostname not in groups['kvmhost']
     - vm_ip is defined and vm_ip
     - virt_infra_state | default(virt_infra_state) == "running"

--- a/tasks/hosts-remove.yml
+++ b/tasks/hosts-remove.yml
@@ -14,7 +14,7 @@
   become: true
   delegate_to: "{{ kvmhost }}"
   when:
-    - virt_infra_add_etc_hosts
+    - virt_infra_add_etc_hosts | default(virt_infra_add_etc_hosts) | bool
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_state | default(virt_infra_state) == "undefined"
   throttle: 1
@@ -47,7 +47,7 @@
   become: false
   delegate_to: "{{ kvmhost }}"
   when:
-    - virt_infra_add_ssh_config
+    - virt_infra_add_ssh_config | default(virt_infra_add_ssh_config) | bool
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_state | default(virt_infra_state) == "undefined"
   throttle: 1

--- a/tasks/hosts-remove.yml
+++ b/tasks/hosts-remove.yml
@@ -14,6 +14,7 @@
   become: true
   delegate_to: "{{ kvmhost }}"
   when:
+    - virt_infra_add_etc_hosts
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_state | default(virt_infra_state) == "undefined"
   throttle: 1
@@ -46,6 +47,7 @@
   become: false
   delegate_to: "{{ kvmhost }}"
   when:
+    - virt_infra_add_ssh_config
     - inventory_hostname not in groups['kvmhost']
     - virt_infra_state | default(virt_infra_state) == "undefined"
   throttle: 1


### PR DESCRIPTION
Fix #73

add options to remove tasks as well

Not adding the key to known_hosts would make the cloud-init check fail as it's asking for the key to be verified.

Could disable strict host checking in ssh, but for now I'll leave it as it is.