### PR TITLE
support boot mode, legacy or uefi

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ virt_infra_cpu_model: "host-passthrough"
 virt_infra_machine_type: "q35"
 
 # What boot mode to use, legacy or uefi
-virt_infra_graphics: legacy
+virt_infra_boot_mode: legacy
 
 # What graphics server to use, spice or vnc
 virt_infra_graphics: spice

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,9 @@ virt_infra_cpus_max: "{{ virt_infra_cpus }}"
 virt_infra_cpu_model: "host-passthrough"
 virt_infra_machine_type: "q35"
 
+# What boot mode to use, legacy or uefi
+virt_infra_graphics: legacy
+
 # What graphics server to use, spice or vnc
 virt_infra_graphics: spice
 

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -60,6 +60,13 @@
     --sound none
     --vcpus {{ virt_infra_cpus }}{% if virt_infra_cpus_max is defined and virt_infra_cpus_max %},maxvcpus={{ virt_infra_cpus_max }}{% endif %}
     --virt-type kvm
+    {% if virt_infra_boot_mode is defined and virt_infra_boot_mode == "uefi" %}
+    --boot loader.readonly=yes
+    --boot loader.type=pflash
+    --boot loader.secure=no
+    --boot loader=/usr/share/OVMF/OVMF_CODE.secboot.fd
+    --boot nvram.template=/usr/share/OVMF/OVMF_VARS.fd
+    {% endif %}
   become: true
   register: result_vm_create
   retries: 10

--- a/tasks/virt-remove.yml
+++ b/tasks/virt-remove.yml
@@ -5,6 +5,9 @@
     undefine {{ inventory_hostname }}
     --managed-save
     --snapshots-metadata
+    {% if virt_infra_boot_mode is defined and virt_infra_boot_mode == "uefi" %}
+    --nvram
+    {% endif %}
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']


### PR DESCRIPTION
Sushy-tools as used with K8s Metal3 requires UEFI booting to support virtual-CD mounting via Redfish. This change allows the user to select uefi as the boot mode for the target VMs.