### PR TITLE
Add support for pci-passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,10 @@ virt_infra_host_deps:
 virt_infra_guest_deps:
   - cloud-init
   - qemu-guest-agent
+
+# Array of ids of devices to be passed to the vm
+# (see virt-install doc for --host-device option)
+virt_infra_host_devices: []
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,3 +137,8 @@ virt_infra_host_deps:
 virt_infra_guest_deps:
   - cloud-init
   - qemu-guest-agent
+
+# Array of ids of devices to be passed to the vm
+# (see virt-install doc for --host-device option)
+virt_infra_host_devices: []
+

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -59,6 +59,11 @@
     --serial pty
     --sound none
     --vcpus {{ virt_infra_cpus }}{% if virt_infra_cpus_max is defined and virt_infra_cpus_max %},maxvcpus={{ virt_infra_cpus_max }}{% endif %}
+    {% if virt_infra_host_devices is defined and virt_infra_host_devices %}
+    {% for hostdev in virt_infra_host_devices %}
+    --host-device {{ hostdev }}
+    {% endfor %}
+    {% endif %}
     --virt-type kvm
   become: true
   register: result_vm_create


### PR DESCRIPTION
Additionally use `--host-device` option(s) of `virt-install` for each host device specified in new option (array) `virt_infra_host_devices`.