### PR TITLE
Additional cloud init config

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,12 @@ So that we can configure the guest and get its IP, both `cloud-init` and
 This can be changed or overridden using the `virt_infra_guest_deps` variable,
 which is a list.
 
+Cloud-init is configured so that passwords and networking can be set up.
+Additional cloud-init root level setup can be attached using the
+`virt_infra_extra_user_data` variable. Using the heredoc format is useful for
+multi-line content. Take care not to duplicate any keys already defined in
+[the template](templates/user-data.j2) as it will either error or override.
+
 Sysprep is also run on the guest image to make sure it's clean of things like
 old MAC addresses.
 
@@ -761,6 +767,10 @@ virt_infra_host_deps:
 virt_infra_guest_deps:
   - cloud-init
   - qemu-guest-agent
+
+# Extra cloud-init data to pass into the user-data for the guest.
+virt_infra_extra_user_data: ""
+
 ```
 
 ## Dependencies

--- a/tasks/pool-create.yml
+++ b/tasks/pool-create.yml
@@ -4,7 +4,7 @@
 # because VMs are started in parallel and multiple VMs will try to start the pool
 # This assumes the pool is called default and uses the path specified in vars, /var/lib/libvirt/images by default
 - name: List storage pools
-  virt_pool:
+  community.libvirt.virt_pool:
     command: list_pools
   register: result_pool_list
   become: true
@@ -12,7 +12,7 @@
     - inventory_hostname in groups['kvmhost']
 
 - name: Get info on storage pools
-  virt_pool:
+  community.libvirt.virt_pool:
     command: info
   register: result_pool_info
   become: true
@@ -20,7 +20,7 @@
     - inventory_hostname in groups['kvmhost']
 
 - name: Define storage pool
-  virt_pool:
+  community.libvirt.virt_pool:
     command: define
     name: default
     xml: '{{ lookup("template", "virt-pool.j2") }}'
@@ -28,10 +28,10 @@
   become: true
   when:
     - inventory_hostname in groups['kvmhost']
-    - '"default" not in result_pool_list'
+    - '"default" not in result_pool_list["list_pools"]'
 
 - name: Build storage pool
-  virt_pool:
+  community.libvirt.virt_pool:
     command: build
     name: default
   become: true
@@ -43,7 +43,7 @@
   ignore_errors: true
 
 - name: Ensure storage pool is active
-  virt_pool:
+  community.libvirt.virt_pool:
     state: "active"
     name: "default"
   become: true

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -48,7 +48,6 @@
     --noreboot
     --noautoconsole
     --events on_reboot=restart
-    --os-type linux
     {% if virt_infra_variant is defined and virt_infra_variant %}
     --os-variant {{ virt_infra_variant }}
     {% else %}

--- a/templates/user-data.j2
+++ b/templates/user-data.j2
@@ -33,3 +33,8 @@ runcmd:
 
 # To know when to log in, if reading console
 final_message: "SYSTEM READY TO LOG IN"
+
+{% if virt_infra_extra_user_data is defined and virt_infra_extra_user_data %}
+# Extra user data
+{{ virt_infra_extra_user_data }}
+{% endif %}


### PR DESCRIPTION
I needed a way to add additional cloud-init configuration, so I whipped this up in hopes it was useful.

In my case, my environment doesn't allow ecdsa keys (yet), so I had to set:
```
virt_infra_extra_user_data: |-
  ssh_genkeytypes: ['rsa']
```

I also changed the "module" to the full modern path, and removed the obsolete --os-type from the virt-install command. Finally, I fixed a problem with detecting the existing "default" pool because it was checking the registered variable, not the result field.