### PR TITLE
Add all existing authorized_keys to found .pub file and inject to the guest

### DIFF
--- a/tasks/defaults-get.yml
+++ b/tasks/defaults-get.yml
@@ -10,7 +10,9 @@
 - name: Find SSH public keys on KVM host for cloud-init if none specified
   find:
     paths: "{{ ansible_env.HOME }}/.ssh/"
-    patterns: '*.pub'
+    patterns:
+      - '*.pub'
+      - 'authorized_keys'
   register: result_ssh_key_list
   changed_when: false
   when:
@@ -28,7 +30,7 @@
 
 - name: Set SSH keys as KVM host default for cloud-init
   set_fact:
-    virt_infra_ssh_keys: "{{ virt_infra_ssh_keys + [ item.stdout ] }}"
+    virt_infra_ssh_keys: "{{ virt_infra_ssh_keys + item.stdout.split('\n') }}"
   with_items: "{{ result_ssh_keys.results }}"
   when:
     - inventory_hostname in groups['kvmhost']


### PR DESCRIPTION
- Note this doesn't work if virt_infra_ssh_keys is specified
- And it breaks generating an SSH key if one is not present. This is an acceptable tradeoff to me since the user can configure agent forwarding.

I'm happy to rework under direction.