### PR TITLE
Add non-x86_64 support for launching VMs in uefi mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,10 +25,25 @@ virt_infra_ram_max: "{{ virt_infra_ram }}"
 virt_infra_cpus: "1"
 virt_infra_cpus_max: "{{ virt_infra_cpus }}"
 virt_infra_cpu_model: "host-passthrough"
-virt_infra_machine_type: "q35"
 
-# What boot mode to use, legacy or uefi
-virt_infra_boot_mode: legacy
+# Use the qemu detected default. This is usually the same as the host CPU. Only change this if the detected machine type
+# isn't ideal.
+virt_infra_machine_type: null
+
+# Boot loader settings for uefi mode
+virt_infra_boot:
+  # What boot mode to use, legacy or uefi. Setting mode=="legacy" omits the --boot option from the virt-install command
+  mode: legacy
+
+  # Boot loader options for uefi mode These paths are valid on x86_64 RedHat and Ubuntu based distros. Any --boot option
+  # can be added here. The key/value pairs will be joined with "=", and then joined together with "," and passed
+  # verbatim to --boot <mode>,<remaining_options>
+  options:
+    loader: "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+    nvram.template: "/usr/share/OVMF/OVMF_VARS.fd"
+    loader.readonly: "yes"
+    loader.type: "pflash"
+    loader.secure: "no"
 
 # What graphics server to use, spice or vnc
 virt_infra_graphics: spice

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ virt_infra_cpu_model: "host-passthrough"
 virt_infra_machine_type: "q35"
 
 # What boot mode to use, legacy or uefi
-virt_infra_graphics: legacy
+virt_infra_boot_mode: legacy
 
 # What graphics server to use, spice or vnc
 virt_infra_graphics: spice

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,9 @@ virt_infra_cpus_max: "{{ virt_infra_cpus }}"
 virt_infra_cpu_model: "host-passthrough"
 virt_infra_machine_type: "q35"
 
+# What boot mode to use, legacy or uefi
+virt_infra_graphics: legacy
+
 # What graphics server to use, spice or vnc
 virt_infra_graphics: spice
 

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -34,7 +34,7 @@
     --disk {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso,device=cdrom,bus=scsi,format=iso
     --channel unix,target_type=virtio,name=org.qemu.guest_agent.0
     --graphics {{ virt_infra_graphics }}
-    --machine {{ virt_infra_machine_type }}
+    {{ virt_infra_machine_type | ternary("--machine " + virt_infra_machine_type|string, "")}}
     --name {{ inventory_hostname }}
     {% for network in virt_infra_networks %}
     {% if network.type is defined and network.type == "bridge" %}
@@ -48,7 +48,6 @@
     --noreboot
     --noautoconsole
     --events on_reboot=restart
-    --os-type linux
     {% if virt_infra_variant is defined and virt_infra_variant %}
     --os-variant {{ virt_infra_variant }}
     {% else %}
@@ -60,12 +59,10 @@
     --sound none
     --vcpus {{ virt_infra_cpus }}{% if virt_infra_cpus_max is defined and virt_infra_cpus_max %},maxvcpus={{ virt_infra_cpus_max }}{% endif %}
     --virt-type kvm
-    {% if virt_infra_boot_mode is defined and virt_infra_boot_mode == "uefi" %}
-    --boot loader.readonly=yes
-    --boot loader.type=pflash
-    --boot loader.secure=no
-    --boot loader=/usr/share/OVMF/OVMF_CODE.secboot.fd
-    --boot nvram.template=/usr/share/OVMF/OVMF_VARS.fd
+    {% if virt_infra_boot.mode is defined %}
+      {% if virt_infra_boot.mode != "legacy" %}
+    --boot {{virt_infra_boot.mode}},{{ virt_infra_boot.options | items | map('join', '=') | join(',') }}
+      {% endif %}
     {% endif %}
   become: true
   register: result_vm_create

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -60,6 +60,13 @@
     --sound none
     --vcpus {{ virt_infra_cpus }}{% if virt_infra_cpus_max is defined and virt_infra_cpus_max %},maxvcpus={{ virt_infra_cpus_max }}{% endif %}
     --virt-type kvm
+    {% if virt_infra_boot_mode is defined and virt_infra_boot_mode == "uefi" %}
+    --boot loader.readonly=yes
+    --boot loader.type=pflash
+    --boot loader.secure=no
+    --boot loader=/usr/share/OVMF/OVMF_CODE.secboot.fd
+    --boot nvram.template=/usr/share/OVMF/OVMF_VARS.fd
+    {% endif %}
   become: true
   register: result_vm_create
   retries: 10

--- a/tasks/virt-remove.yml
+++ b/tasks/virt-remove.yml
@@ -5,6 +5,9 @@
     undefine {{ inventory_hostname }}
     --managed-save
     --snapshots-metadata
+    {% if virt_infra_boot_mode is defined and virt_infra_boot_mode == "uefi" %}
+    --nvram
+    {% endif %}
   become: true
   when:
     - inventory_hostname not in groups['kvmhost']


### PR DESCRIPTION
This PR obsoletes #75 by building additional flexibility.

Changes default machine type to "null" (from q35), which lets libvirt/qemu detect the default.

Adds a  virt_infra_boot config, which is an object with a mode string attribute and options key/value object. The mode and options are assembled and passed to the --boot virt-install option, unless mode=='legacy'.

Removes the obsolete --os-type option.