### PR TITLE
Support newer Ansible versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.retry
 *.swp
+/.ansible/

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ different sizes with multiple networks, disks and even distros!
 All that's really needed is a Linux host, capable of running KVM, some guest
 images and a basic inventory. Ansible will do the rest (on supported distros).
 
-A working x86_64 KVM host where the user running Ansible can communicate with
+A working `x86_64` KVM host where the user running Ansible can communicate with
 `libvirtd` via `sudo`.
 
 It expects hardware support for KVM in the CPU so that we an create accelerated
@@ -179,8 +179,8 @@ virt-install
 
 CentOS 7 won't work until we have `libselinux-python3` package, which is coming in 7.8...
 
-* https://bugzilla.redhat.com/show_bug.cgi?id=1719978
-* https://bugzilla.redhat.com/show_bug.cgi?id=1756015
+* <https://bugzilla.redhat.com/show_bug.cgi?id=1719978>
+* <https://bugzilla.redhat.com/show_bug.cgi?id=1756015>
 
 But here are (hopefully) the rest of the steps for when it is available.
 
@@ -1094,7 +1094,7 @@ same inventory to do whatever you wanted with those machines...
 - hosts: all,!kvmhost
   tasks:
     - name: Upgrade all packages
-      package:
+      ansible.builtin.package:
         name: '*'
         state: latest
       become: true
@@ -1104,7 +1104,7 @@ same inventory to do whatever you wanted with those machines...
       until: result_package_update is succeeded
 
     - name: Install packages
-      package:
+      ansible.builtin.package:
         name:
           - git
           - tmux

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,7 +4,7 @@
 # however ansible doesn't seem to ensure it actually came back up
 # so perform manual stop and start
 - name: "Stop virtualbmc daemon"
-  service:
+  ansible.builtin.service:
     name: "{{ virt_infra_vbmc_service | default('vbmcd') }}"
     state: stopped
     enabled: yes
@@ -16,7 +16,7 @@
     - inventory_hostname in groups['kvmhost']
 
 - name: "Start virtualbmc daemon"
-  service:
+  ansible.builtin.service:
     name: "{{ virt_infra_vbmc_service | default('vbmcd') }}"
     state: started
     enabled: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: GPLv3
 
-  min_ansible_version: 2.8
+  min_ansible_version: "2.16"
   platforms:
     - name: EL
       versions:

--- a/tasks/defaults-get.yml
+++ b/tasks/defaults-get.yml
@@ -1,14 +1,14 @@
 ---
 # Use the KVM host to get defaults for VMs, unless overridden in inventory
 - name: Get details of KVM host
-  setup:
+  ansible.builtin.setup:
   when:
     - inventory_hostname in groups['kvmhost']
 
 # Use SSH keys on KVM host to use as defaults for cloud-init
 # These are only used if no keys are specified
 - name: Find SSH public keys on KVM host for cloud-init if none specified
-  find:
+  ansible.builtin.find:
     paths: "{{ ansible_env.HOME }}/.ssh/"
     patterns: '*.pub'
   register: result_ssh_key_list
@@ -27,7 +27,7 @@
     - hostvars[inventory_hostname].virt_infra_ssh_keys is not defined
 
 - name: Set SSH keys as KVM host default for cloud-init
-  set_fact:
+  ansible.builtin.set_fact:
     virt_infra_ssh_keys: "{{ virt_infra_ssh_keys + [ item.stdout ] }}"
   with_items: "{{ result_ssh_keys.results }}"
   when:
@@ -36,7 +36,7 @@
 
 # If no SSH keys found or specified, we create one, which requires ~/.ssh dir to exist
 - name: Ensure SSH dir exists if no SSH keys found or specified
-  file:
+  ansible.builtin.file:
     path: "{{ ansible_env.HOME }}/.ssh"
     state: directory
   when:
@@ -45,7 +45,7 @@
     - result_ssh_key_list.files | length == 0
 
 - name: Create SSH keypair if none found or specified
-  openssh_keypair:
+  community.crypto.openssh_keypair:
     path: "{{ ansible_env.HOME }}/.ssh/id_{{ virt_infra_ssh_key_type | default('rsa') }}-virt-infra-ansible"
     size: "{{ virt_infra_ssh_key_size }}"
     type: "{{ virt_infra_ssh_key_type }}"
@@ -57,7 +57,7 @@
     - result_ssh_key_list.files | length == 0
 
 - name: Set created SSH key as KVM host default for cloud-init
-  set_fact:
+  ansible.builtin.set_fact:
     virt_infra_ssh_keys: "{{ virt_infra_ssh_keys + [ result_ssh_key_gen.public_key ] }}"
   when:
     - inventory_hostname in groups['kvmhost']
@@ -82,7 +82,7 @@
     executable: /bin/bash
 
 - name: Store timezone from KVM host
-  set_fact:
+  ansible.builtin.set_fact:
     virt_infra_timezone: "{{ result_timezone.stdout }}"
   when:
     - inventory_hostname in groups['kvmhost']

--- a/tasks/defaults-get.yml
+++ b/tasks/defaults-get.yml
@@ -18,7 +18,7 @@
     - hostvars[inventory_hostname].virt_infra_ssh_keys is not defined
 
 - name: Read public SSH keys on KVM host if none specified
-  command: "cat {{ item.path }}"
+  ansible.builtin.command: "cat {{ item.path }}"
   register: result_ssh_keys
   with_items: "{{ result_ssh_key_list.files }}"
   changed_when: false
@@ -70,7 +70,7 @@
 # as it's an achronym which can't be resolved to country/city for cloud-init
 # Due to Ubuntu Bionic, can't use 'timedatectl -p Timezone --value show'
 - name: Get timezone from KVM host for cloud-init
-  shell: |
+  ansible.builtin.shell: |
     set -o pipefail
     timedatectl |grep 'Time zone:' |awk '{ print $3 }'
   register: result_timezone

--- a/tasks/defaults-set.yml
+++ b/tasks/defaults-set.yml
@@ -1,0 +1,15 @@
+---
+# Set defaults for the guests based on the KVM host
+- name: Use KVM host architecture for VMs when not specified
+  ansible.builtin.set_fact:
+    virt_infra_architecture: "{{ hostvars[kvmhost].ansible_architecture }}"
+  when:
+    - inventory_hostname not in groups['kvmhost']
+    - virt_infra_architecture is not defined
+
+- name: Use KVM host domain for VMs when not specified
+  ansible.builtin.set_fact:
+    virt_infra_domainname: "{{ hostvars[kvmhost].ansible_domain }}"
+  when:
+    - inventory_hostname not in groups['kvmhost']
+    - virt_infra_domainname is not defined

--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -7,7 +7,7 @@
 # Ideally, boot should be defined first in virt_infra_disks so that it's /dev/sda
 
 - name: Check if boot disk already exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2"
   register: result_stat_boot
   when:
@@ -16,7 +16,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Check if boot disk is set to keep
-  set_fact:
+  ansible.builtin.set_fact:
     keep_boot: "{{ item.keep }}"
   with_items: "{{ virt_infra_disks }}"
   when:
@@ -26,7 +26,7 @@
     - item.keep is defined and item.keep
 
 - name: Create boot disk for VM
-  command: >
+  ansible.builtin.command: >
     qemu-img
     {% if item.clone is defined and item.clone %}
     convert -f qcow2 -O qcow2
@@ -48,7 +48,7 @@
   with_items: "{{ virt_infra_disks }}"
 
 - name: Resize boot disk for VM
-  command: >
+  ansible.builtin.command: >
     qemu-img
     resize
     {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2
@@ -64,7 +64,7 @@
   with_items: "{{ virt_infra_disks }}"
 
 - name: Create additional disks for VM
-  command: >
+  ansible.builtin.command: >
     qemu-img create -f qcow2
     {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2
     {{ item.size | default(virt_infra_disk_size) }}G
@@ -83,7 +83,7 @@
 # Due to the way NVME works with qemu (as args),
 # we need specific permissions on the image
 - name: Set permissions on NVMe disk images
-  file:
+  ansible.builtin.file:
     path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
     owner: "{{ hostvars[kvmhost].virt_infra_host_image_owner | default('root') }}"
     group: "{{ hostvars[kvmhost].virt_infra_host_image_group | default('qemu') }}"
@@ -102,7 +102,7 @@
 
 ## Create cloudinit iso
 - name: Create temporary dir to build cloud-init config
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
     suffix: cloudinit
   register: result_tempdir
@@ -114,7 +114,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Create cloud init meta-data for guest
-  template:
+  ansible.builtin.template:
     src: templates/meta-data.j2
     dest: "{{ result_tempdir.path }}/meta-data"
     mode: '0644'
@@ -126,7 +126,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Create cloud init user-data for guest
-  template:
+  ansible.builtin.template:
     src: templates/user-data.j2
     dest: "{{ result_tempdir.path }}/user-data"
     mode: '0644'
@@ -138,7 +138,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Create cloud init network-config for guest
-  template:
+  ansible.builtin.template:
     src: templates/network-config.j2
     dest: "{{ result_tempdir.path }}/network-config"
     mode: '0644'
@@ -168,7 +168,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Clean up temporary dir
-  file:
+  ansible.builtin.file:
     path: "{{ result_tempdir.path }}"
     state: absent
   when:
@@ -178,7 +178,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Run custom shell commands in guest disk
-  command: >
+  ansible.builtin.command: >
     virt-customize
     -a {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
     {% if virt_infra_disk_cmd is defined and virt_infra_disk_cmd %}
@@ -200,7 +200,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Install required packages into guest disk
-  command: >
+  ansible.builtin.command: >
     virt-customize
     -a {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
     {% if virt_infra_sm_creds is defined and virt_infra_sm_creds %}
@@ -224,7 +224,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Remove RHEL registration
-  command: >
+  ansible.builtin.command: >
     virt-customize
     -a {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-boot.qcow2
     {% if virt_infra_sm_creds is defined and virt_infra_sm_creds %}
@@ -245,7 +245,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Sysprep guest disk
-  command: >
+  ansible.builtin.command: >
     virt-sysprep
     --selinux-relabel
     {% if virt_infra_root_password is defined and virt_infra_root_password %}

--- a/tasks/disk-create.yml
+++ b/tasks/disk-create.yml
@@ -151,7 +151,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Make cloud-init iso for guest
-  shell: >
+  ansible.builtin.shell: >
     {{ hostvars[kvmhost].virt_infra_mkiso_cmd | default(virt_infra_mkiso_cmd) }} -J -l -R -V "cidata" -iso-level 4
     -o {{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso
     {{ result_tempdir.path }}/user-data

--- a/tasks/disk-remove.yml
+++ b/tasks/disk-remove.yml
@@ -5,7 +5,7 @@
 # So let's just check they're all gone
 # Only remove disks if the guest is not running and it's set to undefined
 - name: Remove guest disks
-  file:
+  ansible.builtin.file:
     path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-{{ item.name }}.qcow2"
     state: absent
   become: true
@@ -18,7 +18,7 @@
   with_items: "{{ virt_infra_disks }}"
 
 - name: Remove guest cloud-init ISO
-  file:
+  ansible.builtin.file:
     path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ inventory_hostname }}-cloudinit.iso"
     state: absent
   become: true

--- a/tasks/hosts-add.yml
+++ b/tasks/hosts-add.yml
@@ -7,7 +7,7 @@
 # Thus, while this should be run against the kvmhost host, it will show one of your guests
 
 - name: Update /etc/hosts to resolve new VMs
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: /etc/hosts
     state: present
     marker: "# {mark} {{ inventory_hostname }} managed by virt_infra Ansible playbook"
@@ -24,10 +24,10 @@
 #  run_once: true
 
 - name: Add host to SSH config
-  blockinfile:
+  ansible.builtin.blockinfile:
     create: true
-    mode: 0600
-    state: present
+    mode: "0600"
+    state: "present"
     path: "{{ hostvars[kvmhost].ansible_env.HOME }}/.ssh/config"
     marker: "# {mark} {{ inventory_hostname }} managed by virt_infra Ansible playbook"
     block: |-

--- a/tasks/hosts-remove.yml
+++ b/tasks/hosts-remove.yml
@@ -6,7 +6,7 @@
 # Because serial is messy and requires custom plays, I'm doing the latter
 # Thus, while this should be run against the kvmhost host, the task out show as being against one of your guests
 - name: Remove guests from /etc/hosts
-  blockinfile:
+  ansible.builtin.blockinfile:
     create: true
     state: absent
     path: /etc/hosts
@@ -21,7 +21,7 @@
 #  run_once: true
 
 - name: Remove guests from SSH known_hosts
-  blockinfile:
+  ansible.builtin.blockinfile:
     create: true
     mode: 0600
     state: absent
@@ -37,7 +37,7 @@
 #  run_once: true
 
 - name: Remove guests from SSH config
-  blockinfile:
+  ansible.builtin.blockinfile:
     create: true
     mode: 0600
     state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,7 @@
 - include_tasks: net-list.yml
 - include_tasks: net-remove.yml
 - include_tasks: net-create.yml
+- include_tasks: defaults-set.yml
 - include_tasks: pool-create.yml
 - include_tasks: disk-create.yml
 - include_tasks: virt-create.yml
@@ -21,7 +22,7 @@
 - include_tasks: wait.yml
 
 - name: Advise if SSH key was created
-  debug:
+  ansible.builtin.debug:
     msg: item
   with_items:
     - SSH key created at {{ result_ssh_key_gen.filename }}

--- a/tasks/net-create.yml
+++ b/tasks/net-create.yml
@@ -1,7 +1,7 @@
 ---
 # Only run on KVM host
 - name: Define networks
-  virt_net:
+  community.libvirt.virt_net:
     command: define
     autostart: yes
     name: "{{ item.name }}"
@@ -15,7 +15,7 @@
     - item.name is defined
 
 - name: Start networks
-  virt_net:
+  community.libvirt.virt_net:
     state: active
     name: "{{ item.name }}"
     uri: "{{ virt_infra_host_libvirt_url }}"
@@ -27,7 +27,7 @@
     - item.name is defined
 
 - name: Autostart networks
-  virt_net:
+  community.libvirt.virt_net:
     autostart: yes
     name: "{{ item.name }}"
     uri: "{{ virt_infra_host_libvirt_url }}"

--- a/tasks/net-list.yml
+++ b/tasks/net-list.yml
@@ -3,7 +3,7 @@
 # If network list already defined, then move the variable.
 # This way we can get the latest and previous list of networks
 - name: Move network details to old list
-  set_fact:
+  ansible.builtin.set_fact:
     result_libvirt_network_before: "{{ result_libvirt_network }}"
   when:
     - inventory_hostname in groups['kvmhost']
@@ -12,7 +12,7 @@
   changed_when: false
 
 - name: Move list of networks to old list
-  set_fact:
+  ansible.builtin.set_fact:
     result_libvirt_network_list_before: "{{ result_libvirt_network_list }}"
   when:
     - inventory_hostname in groups['kvmhost']
@@ -22,7 +22,7 @@
 
 # Only run on KVM host
 - name: Get network facts
-  virt_net:
+  community.libvirt.virt_net:
     command: facts
     name: "{{ item.name }}"
     uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
@@ -34,7 +34,7 @@
     - inventory_hostname in groups['kvmhost']
 
 - name: Get network list
-  virt_net:
+  community.libvirt.virt_net:
     command: list_nets
     name: dummy
     uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"

--- a/tasks/net-remove.yml
+++ b/tasks/net-remove.yml
@@ -1,7 +1,7 @@
 ---
 # Only run on KVM host
 - name: Stop networks
-  virt_net:
+  community.libvirt.virt_net:
     state: inactive
     name: "{{ item.name }}"
   with_items: "{{ virt_infra_host_networks.absent }}"
@@ -12,7 +12,7 @@
   become: true
 
 - name: Undefine networks
-  virt_net:
+  community.libvirt.virt_net:
     command: undefine
     name: "{{ item.name }}"
     xml: '{{ lookup("template", "templates/virt-network.j2") }}'

--- a/tasks/pool-create.yml
+++ b/tasks/pool-create.yml
@@ -4,7 +4,7 @@
 # because VMs are started in parallel and multiple VMs will try to start the pool
 # This assumes the pool is called default and uses the path specified in vars, /var/lib/libvirt/images by default
 - name: List storage pools
-  virt_pool:
+  community.libvirt.virt_pool:
     command: list_pools
   register: result_pool_list
   become: true
@@ -12,7 +12,7 @@
     - inventory_hostname in groups['kvmhost']
 
 - name: Get info on storage pools
-  virt_pool:
+  community.libvirt.virt_pool:
     command: info
   register: result_pool_info
   become: true
@@ -20,7 +20,7 @@
     - inventory_hostname in groups['kvmhost']
 
 - name: Define storage pool
-  virt_pool:
+  community.libvirt.virt_pool:
     command: define
     name: default
     xml: '{{ lookup("template", "virt-pool.j2") }}'
@@ -31,7 +31,7 @@
     - '"default" not in result_pool_list'
 
 - name: Build storage pool
-  virt_pool:
+  community.libvirt.virt_pool:
     command: build
     name: default
   become: true
@@ -43,7 +43,7 @@
   ignore_errors: true
 
 - name: Ensure storage pool is active
-  virt_pool:
+  community.libvirt.virt_pool:
     state: "active"
     name: "default"
   become: true

--- a/tasks/validations-initial.yml
+++ b/tasks/validations-initial.yml
@@ -2,7 +2,7 @@
 # Guests need to have a KVM host to deploy to
 # If it is not defined (or defined to empty string), we default to the first kvmhost in the kvmhost group.
 - name: "Guests: Ensure a KVM host is defined"
-  set_fact:
+  ansible.builtin.set_fact:
     kvmhost: "{{ groups['kvmhost'][0] }}"
   when:
     - inventory_hostname not in groups['kvmhost']
@@ -26,7 +26,7 @@
     # Convert it to a list so we can easily check either 'kvmhost' or 'all' is there
     # I think this is a bit cleaner than regex and should catch other combinations
     - name: Convert --limit into a list for validation
-      set_fact:
+      ansible.builtin.set_fact:
         limit_list: "{{ ansible_limit.split(',') }}"
       delegate_to: "{{ groups['kvmhost'][0] }}"
       run_once: true
@@ -34,7 +34,7 @@
         - ansible_limit is defined
 
     - name: "Guests: Check that KVM host exists in inventory"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host ' + kvmhost + ' not in kvmhost group'] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -42,7 +42,7 @@
       changed_when: true
 
     - name: "Guests: Check that KVM host is in limit"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host ' + kvmhost + ' not in limit, include --limit kvmhost option'] }}"
       when:
         - ansible_limit is defined
@@ -51,14 +51,14 @@
       changed_when: true
 
     - name: Validation failures
-      debug:
+      ansible.builtin.debug:
         msg: "{{ validations_failed|default('nothing') }}"
       when:
         - validations_failed is defined and validations_failed
       failed_when: true
 
   rescue:
-    - debug:
+    - ansible.builtin.debug:
         msg: "Play aborted, see errors above"
       changed_when: true
 

--- a/tasks/validations.yml
+++ b/tasks/validations.yml
@@ -4,7 +4,7 @@
   block:
     ## KVM host
     - name: "KVM host only: Get distro and network devices to validate guest configs"
-      setup:
+      ansible.builtin.setup:
         gather_subset:
           - '!all'
           - min
@@ -14,7 +14,7 @@
         - inventory_hostname in groups['kvmhost']
 
     - name: "Abort play if KVM host is unreachable"
-      assert:
+      ansible.builtin.assert:
         that: result_setup.unreachable is not defined
         fail_msg: "KVM host unreachable, please check inventory"
         quiet: true
@@ -23,19 +23,19 @@
 
     # Load distro specific vars here
     - name: "KVM host only: Load distro specific vars"
-      include_vars: "{{ lookup('first_found', params) }}"
+      ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
       vars:
         params:
           files:
-            - "{{ ansible_distribution.split(' ', 1)[0] | lower }}.yml"
-            - "{{ ansible_os_family.split(' ', 1)[0] | lower }}.yml"
+            - "{{ ansible_facts['distribution'].split(' ', 1)[0] | lower }}.yml"
+            - "{{ ansible_facts['os_family'].split(' ', 1)[0] | lower }}.yml"
           paths:
             - vars
       when:
         - inventory_hostname in groups['kvmhost']
 
     - name: "KVM host only: Install KVM and libvirtd packages"
-      package:
+      ansible.builtin.package:
         name: "{{ virt_infra_host_pkgs_kvm }}"
         state: present
       become: true
@@ -48,7 +48,7 @@
       ignore_errors: true
 
     - name: "KVM host only: Advise unable to install KVM and libvirtd packages"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to install kvm and libvirtd packages'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -56,7 +56,7 @@
       changed_when: true
 
     - name: "KVM host only: Install required packages"
-      package:
+      ansible.builtin.package:
         name: "{{ virt_infra_host_pkgs_deps }}"
         state: present
       become: true
@@ -69,7 +69,7 @@
       ignore_errors: true
 
     - name: "KVM host only: Advise unable to install packages"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to install deps'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -77,7 +77,7 @@
       changed_when: true
 
     - name: "KVM host only: Install custom packages"
-      package:
+      ansible.builtin.package:
         name: "{{ virt_infra_host_pkgs_custom }}"
         state: present
       become: true
@@ -94,7 +94,7 @@
       ignore_errors: true
 
     - name: "KVM host only: Advise unable to install custom packages"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to install custom packages'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -119,7 +119,7 @@
     # Defaults to "none" when not specified, which enables use of NVMe drives successfully on all distros
     # Else we get permissions denied on NVMe disk images
     - name: "KVM host only: Set libvirtd security driver"
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /etc/libvirt/qemu.conf
         insertafter: '^#\s*security_driver\s*='
         regexp: '^security_driver\s*='
@@ -130,7 +130,7 @@
       become: true
 
     - name: "KVM host only: Restart libvirtd if config changed"
-      service:
+      ansible.builtin.service:
         name: "libvirtd"
         state: restarted
         enabled: yes
@@ -142,7 +142,7 @@
       become: true
 
     - name: "KVM host only: Ensure libvirtd is running"
-      service:
+      ansible.builtin.service:
         name: "libvirtd"
         state: started
         enabled: yes
@@ -153,7 +153,7 @@
       become: true
 
     - name: "KVM host only: Advise unable to start libvirtd"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to start and enable libvirtd'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -162,7 +162,7 @@
 
     # TODO: use this? 'virt-host-validate qemu'
     - name: "KVM host only: Test that we can talk to libvirtd"
-      virt:
+      community.libvirt.virt:
         command: list_vms
         uri: "{{ virt_infra_host_libvirt_url }}"
       register: result_libvirtd
@@ -172,7 +172,7 @@
       ignore_errors: true
 
     - name: "KVM host only: Advise libvirtd not contactable"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: libvirtd connection failed on KVM host'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -183,7 +183,7 @@
     # Make sure it's loaded and disable in next task
     # https://wiki.libvirt.org/page/Net.bridge.bridge-nf-call_and_sysctl.conf
     - name: "KVM host only: Load br_netfilter module"
-      modprobe:
+      community.general.modprobe:
         name: br_netfilter
         state: present
       register: result_modules
@@ -193,7 +193,7 @@
       ignore_errors: true
 
     - name: "KVM host only: Load br_netfilter module on boot"
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /etc/modules-load.d/99-br_netfilter.conf
         line: br_netfilter
         state: present
@@ -205,7 +205,7 @@
         - not result_modules.failed
 
     - name: "KVM host only: Ensure netfilter disabled on bridge"
-      sysctl:
+      ansible.posix.sysctl:
         name: "{{ item }}"
         value: "0"
         sysctl_set: yes
@@ -224,7 +224,7 @@
       ignore_errors: true
 
     - name: "KVM host only: Advise unable to disable netfilter on bridge"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: could not disable netfilter on bridge'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -235,7 +235,7 @@
     # Allow MAC access to NVMe drives when using apparmor
     # Else we get permissions denied on NVMe disk images
     - name: "KVM host only: Enable access to NVMe drives in apparmor"
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /etc/apparmor.d/abstractions/libvirt-qemu
         line: '  /var/lib/libvirt/images/*nvme.qcow2 rwk,'
       register: result_apparmor_conf
@@ -245,7 +245,7 @@
       become: true
 
     - name: "KVM host only: Restart apparmor if config changed"
-      service:
+      ansible.builtin.service:
         name: "apparmor"
         state: restarted
         enabled: yes
@@ -258,7 +258,7 @@
       become: true
 
     - name: "KVM host only: Ensure system package of virtualbmc is removed"
-      package:
+      ansible.builtin.package:
         name: "python3-virtualbmc"
         state: absent
       become: true
@@ -272,7 +272,7 @@
       ignore_errors: true
 
     - name: "KVM host only: Advise unable to remove virtualbmc host package"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to remove vbmc host package'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -281,7 +281,7 @@
       changed_when: true
 
     - name: "KVM host only: Install virtualbmc with pip"
-      pip:
+      ansible.builtin.pip:
         name: virtualbmc  {%- if virt_infra_vbmc_pip_version is defined %}=={{ virt_infra_vbmc_pip_version }}{% endif %}
         extra_args: "--prefix /usr/local"
       register: result_vbmc_pip
@@ -304,7 +304,7 @@
       ignore_errors: yes
 
     - name: "KVM host only: Advise unable to find virtualbmc"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Cannot find vbmc binary, is it installed?'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -313,7 +313,7 @@
       changed_when: true
 
     - name: "KVM host only: Advise unable to install virtualbmc"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to install virtualbmc with pip'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -322,7 +322,7 @@
       changed_when: true
 
     - name: "KVM host only: Create virtualbmc service file"
-      template:
+      ansible.builtin.template:
         src: templates/vbmcd.service.j2
         dest: "/etc/systemd/system/vbmcd.service"
         mode: '0644'
@@ -334,7 +334,7 @@
         - virt_infra_vbmc and virt_infra_vbmc_pip
 
     - name: "KVM host only: Advise unable to create virtualbmc service"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to create virtualbmc service'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -343,7 +343,7 @@
       changed_when: true
 
     - name: "KVM host only: Create virtualbmc config directory"
-      file:
+      ansible.builtin.file:
         path: /etc/virtualbmc
         state: directory
         mode: '0755'
@@ -354,7 +354,7 @@
         - virt_infra_vbmc and virt_infra_vbmc_pip
 
     - name: "KVM host only: Create virtualbmc run directory"
-      file:
+      ansible.builtin.file:
         path: /var/lib/vbmcd
         state: directory
         mode: '0755'
@@ -365,7 +365,7 @@
         - virt_infra_vbmc and virt_infra_vbmc_pip
 
     - name: "KVM host only: Create config for virtualbmc"
-      template:
+      ansible.builtin.template:
         src: templates/virtualbmc.conf.j2
         dest: "/etc/virtualbmc/virtualbmc.conf"
         mode: '0644'
@@ -376,7 +376,7 @@
         - virt_infra_vbmc and virt_infra_vbmc_pip
 
     - name: "KVM host only: Ensure virtualbmc is running"
-      systemd:
+      ansible.builtin.systemd:
         name: "{{ virt_infra_vbmc_service }}"
         state: restarted
         daemon_reload: yes
@@ -390,7 +390,7 @@
       become: true
 
     - name: "KVM host only: Advise unable to start virtualbmc"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: Failed to start and enable virtualbmc'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -411,7 +411,7 @@
       changed_when: false
 
     - name: Advise when deps are not installed
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ 'KVM host: ' +  item.item + ' not found on KVM host, please install'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -428,7 +428,7 @@
       changed_when: false
 
     - name: "KVM host only: Advise os variants not available"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['KVM host: os variants list (osinfo-query os) failed'] }}"
       when:
         - inventory_hostname in groups['kvmhost']
@@ -438,7 +438,7 @@
 
     ## Guests
     - name: "Guests: Check that boot disk is specified"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['boot disk is not defined'] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -446,7 +446,7 @@
       changed_when: true
 
     - name: "Guests: Check that state is valid"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ virt_infra_state + ' not a valid state, try: running, shutdown, destroyed or undefined'] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -454,7 +454,7 @@
       changed_when: true
 
     - name: "KVM host: Test for distro images"
-      stat:
+      ansible.builtin.stat:
         path: "{{ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) }}/{{ virt_infra_distro_image }}"
       register: result_base_image
       delegate_to: "{{ kvmhost }}"
@@ -462,7 +462,7 @@
         - inventory_hostname not in groups['kvmhost']
 
     - name: "Guests: Check that distro disk image exists on KVM host"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + \
         [ hostvars[kvmhost].virt_infra_host_image_path | default(virt_infra_host_image_path) + '/' + \
         virt_infra_distro_image + ' missing.{% if virt_infra_distro_image_url is defined and virt_infra_distro_image_url %} \
@@ -473,7 +473,7 @@
       changed_when: true
 
     - name: "Guests: Check required network is to be removed"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ item.name + ' network required, but would be removed' ] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -484,7 +484,7 @@
       changed_when: true
 
     - name: "Guests: Check required network is present"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ item.name + ' network required, but not being created' ] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -496,7 +496,7 @@
       changed_when: true
 
     - name: "Guests: Check OVS network has bridge specified"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ item.name + ' OVS network does not specify OVS bridge device (bridge_dev)' ] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -508,17 +508,17 @@
       changed_when: true
 
     - name: "Guests: Check if required bridge interfaces exist on KVM host"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ item.name + ' bridge interface missing on KVM host'] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
         - item.type is defined and item.type == "bridge"
-        - item.name not in hostvars[kvmhost].ansible_interfaces
+        - item.name not in hostvars[kvmhost].ansible_facts['interfaces']
       with_items: "{{ virt_infra_networks }}"
       changed_when: true
 
     - name: "Guests: Check that network model is valid"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ item.model + ' network model not valid, try: virtio, e1000, rtl8139' ] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -527,7 +527,7 @@
       changed_when: true
 
     - name: "Guests: Check that os-variant is supported on KVM host"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + [ virt_infra_variant + ' not supported by KVM host, run: sudo osinfo-query os'] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -537,7 +537,7 @@
       changed_when: true
 
     - name: "Guests: Check that existing vbmc port and name match"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['vbmc port exists on ' + item.Port | string + ' but does not match definition of ' + virt_infra_vbmc_port | string ] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -548,7 +548,7 @@
       changed_when: true
 
     - name: "Guests: Check that vbmc port does not conflict with existing"
-      set_fact:
+      ansible.builtin.set_fact:
         validations_failed: "{{ validations_failed|default([]) + ['vbmc port ' + item.Port | string + ' conflicts with ' + item.Name ] }}"
       when:
         - inventory_hostname not in groups['kvmhost']
@@ -562,14 +562,14 @@
     # - name: "Fail if no SSH keys found on kvm host and not defined"
 
     - name: Validation failures
-      debug:
+      ansible.builtin.debug:
         msg: "{{ validations_failed|default('nothing') }}"
       when:
         - validations_failed is defined and validations_failed
       failed_when: true
 
   rescue:
-    - debug:
+    - ansible.builtin.debug:
         msg: "Play aborted, see errors above"
       changed_when: true
 

--- a/tasks/validations.yml
+++ b/tasks/validations.yml
@@ -102,7 +102,7 @@
       changed_when: true
 
     - name: "KVM host only: Test for required programs"
-      shell: 'hash {{ item }} 2>/dev/null'
+      ansible.builtin.shell: 'hash {{ item }} 2>/dev/null'
       become: true
       register: result_deps
       with_items: "{{ virt_infra_host_deps }}"
@@ -295,7 +295,7 @@
       become: true
 
     - name: "KVM host only: Find the path for virtualbmc"
-      command: "which vbmc"
+      ansible.builtin.command: "which vbmc"
       register: result_vbmc_path
       when:
         - inventory_hostname in groups['kvmhost']
@@ -399,7 +399,7 @@
       changed_when: true
 
     - name: "KVM host only: Get virtual BMC list"
-      shell: vbmc list -f json --noindent |sed 's/Domain name/Name/g'
+      ansible.builtin.shell: vbmc list -f json --noindent |sed 's/Domain name/Name/g'
       register: result_vbmc_list
       become: true
       args:
@@ -420,7 +420,7 @@
       with_items: "{{ result_deps.results }}"
 
     - name: "KVM host only: Get list of supported os-variants"
-      command: osinfo-query os
+      ansible.builtin.command: osinfo-query os
       register: result_osinfo
       when:
         - inventory_hostname in groups['kvmhost']

--- a/tasks/vbmc-create.yml
+++ b/tasks/vbmc-create.yml
@@ -1,7 +1,7 @@
 ---
 # Create any virtual BMC interfaces
 - name: Create virtual BMC
-  shell: >
+  ansible.builtin.shell: >
     {{ hostvars[kvmhost].result_vbmc_path.stdout }} add {{ inventory_hostname }}
     --libvirt-uri {{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     --port {{ virt_infra_vbmc_port }}
@@ -25,7 +25,7 @@
     - restart virtual bmc
 
 - name: Start virtual BMC
-  shell: "set -o pipefail && {{ hostvars[kvmhost].result_vbmc_path.stdout }} start {{ inventory_hostname }}"
+  ansible.builtin.shell: "set -o pipefail && {{ hostvars[kvmhost].result_vbmc_path.stdout }} start {{ inventory_hostname }}"
   args:
     executable: /bin/bash
   become: true

--- a/tasks/vbmc-list.yml
+++ b/tasks/vbmc-list.yml
@@ -1,7 +1,7 @@
 ---
 # This is only run on KVM host
 - name: Get virtual BMC list
-  shell: "set -o pipefail && {{ result_vbmc_path.stdout }} list -f json --noindent |sed 's/Domain name/Name/g'"
+  ansible.builtin.shell: "set -o pipefail && {{ result_vbmc_path.stdout }} list -f json --noindent |sed 's/Domain name/Name/g'"
   register: result_vbmc_list
   become: true
   args:

--- a/tasks/vbmc-remove.yml
+++ b/tasks/vbmc-remove.yml
@@ -1,6 +1,6 @@
 ---
 - name: Remove virtual BMC
-  shell: "set -o pipefail && {{ hostvars[kvmhost].result_vbmc_path.stdout }} delete {{ inventory_hostname }}"
+  ansible.builtin.shell: "set -o pipefail && {{ hostvars[kvmhost].result_vbmc_path.stdout }} delete {{ inventory_hostname }}"
   args:
     executable: /bin/bash
   become: true

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -48,7 +48,6 @@
     --noreboot
     --noautoconsole
     --events on_reboot=restart
-    --os-type linux
     {% if virt_infra_variant is defined and virt_infra_variant %}
     --os-variant {{ virt_infra_variant }}
     {% else %}
@@ -75,7 +74,7 @@
 
 # Set VM state, unless it doesn't yet exist and is set to "undefined"
 - name: Set state of VM
-  virt:
+  community.libvirt.virt:
     name: "{{ inventory_hostname }}"
     state: "{{ 'destroyed' if ( virt_infra_state == 'undefined' or (virt_infra_state == 'shutdown' and inventory_hostname in inventory_hostname not in hostvars[kvmhost].result_running_vms.list_vms)) else virt_infra_state }}"
     autostart: "{{ virt_infra_autostart }}"
@@ -121,7 +120,7 @@
     executable: /bin/bash
 
 - name: Store IP of VM
-  set_fact:
+  ansible.builtin.set_fact:
     vm_ip: "{{ result_get_ip.stdout }}"
   when:
     - inventory_hostname not in groups['kvmhost']

--- a/tasks/virt-create.yml
+++ b/tasks/virt-create.yml
@@ -1,7 +1,7 @@
 ---
 # Define the VM, unless it doesn't yet exist and is set to "undefined"
 - name: Define VM
-  shell: >
+  ansible.builtin.shell: >
     set -o pipefail && virt-install
     --import
     --connect {{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
@@ -92,7 +92,7 @@
 # Wait for network so we can get the IP to log in
 # Do this for all VMs, in case they already existed and IP has changed
 - name: Get IP address of VM
-  shell: >
+  ansible.builtin.shell: >
     set -o pipefail ;
     virsh
     --connect {{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}

--- a/tasks/virt-list.yml
+++ b/tasks/virt-list.yml
@@ -3,7 +3,7 @@
 # If result_all_vms already defined, then move the variable.
 # This way we can get the latest and previous list of VMs
 - name: Move list of all VMs to old list
-  set_fact:
+  ansible.builtin.set_fact:
     result_all_vms_before: "{{ result_all_vms }}"
   when:
     - inventory_hostname in groups['kvmhost']
@@ -11,7 +11,7 @@
   changed_when: false
 
 - name: Move list of running VMs to old list
-  set_fact:
+  ansible.builtin.set_fact:
     result_running_vms_before: "{{ result_running_vms }}"
   when:
     - inventory_hostname in groups['kvmhost']
@@ -19,7 +19,7 @@
   changed_when: false
 
 - name: Get list of all VMs
-  virt:
+  community.libvirt.virt:
     command: list_vms
     uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
   register: result_all_vms
@@ -28,7 +28,7 @@
     - inventory_hostname in groups['kvmhost']
 
 - name: Get list of running VMs
-  virt:
+  community.libvirt.virt:
     command: list_vms
     state: running
     uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
@@ -38,7 +38,7 @@
     - inventory_hostname in groups['kvmhost']
 
 - name: Get info on all VMs
-  virt:
+  community.libvirt.virt:
     command: info
     uri: "{{ virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}"
   register: result_info_vms

--- a/tasks/virt-remove.yml
+++ b/tasks/virt-remove.yml
@@ -1,6 +1,6 @@
 ---
 - name: Undefine VM
-  command: >
+  ansible.builtin.command: >
     virsh --connect {{ hostvars[kvmhost].virt_infra_host_libvirt_url | default(virt_infra_host_libvirt_url) }}
     undefine {{ inventory_hostname }}
     --managed-save

--- a/tasks/wait.yml
+++ b/tasks/wait.yml
@@ -31,7 +31,7 @@
     - virt_infra_state is defined and virt_infra_state == "running"
 
 - name: Add guest fingerprint to SSH known_hosts
-  blockinfile:
+  ansible.builtin.blockinfile:
     create: true
     mode: 0600
     state: present

--- a/tasks/wait.yml
+++ b/tasks/wait.yml
@@ -20,7 +20,7 @@
   delegate_to: "{{ kvmhost }}"
 
 - name: Get guest SSH fingerprints
-  shell: "set -o pipefail && ssh-keyscan {{ inventory_hostname }} {{ vm_ip }} | sort"
+  ansible.builtin.shell: "set -o pipefail && ssh-keyscan {{ inventory_hostname }} {{ vm_ip }} | sort"
   args:
     executable: /bin/bash
   delegate_to: "{{ kvmhost }}"
@@ -52,7 +52,7 @@
 # This is not using wait_for module with path option anymore because it doesn't
 # work when kvmhost is remote
 - name: Wait for cloud-init to finish
-  shell: ssh {{ inventory_hostname }} stat /etc/cloud/cloud-init.disabled
+  ansible.builtin.shell: ssh {{ inventory_hostname }} stat /etc/cloud/cloud-init.disabled
   register: result_wait_cloudinit
   retries: 60
   delay: 2


### PR DESCRIPTION
Improvements to support newer versions of Ansible:

- Use fully qualified module names (for modules that are no longer builtin)
- Replace `ansible_*` vars with `ansible_facts